### PR TITLE
CI/CD for UnityPackage

### DIFF
--- a/.github/workflows/unitypackage.yaml
+++ b/.github/workflows/unitypackage.yaml
@@ -5,8 +5,6 @@ on:
   release:
     types:
       - published
-  # DEBUG
-  push:
 
 jobs:
   unitypackage:


### PR DESCRIPTION
This PR adds:
- Basic building that outputs a `.unitypackage` containing the Unity Resonite SDK.
- Publishing to releases when a new version is tagged and published.

Closes https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/6342