### PR TITLE
Fix IDs in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/assets.yml
+++ b/.github/ISSUE_TEMPLATE/assets.yml
@@ -39,7 +39,7 @@ body:
       required: true
 
   - type: textarea
-    id: issue
+    id: expect
     attributes:
       label: 'What were you expecting?'
       description: 'Describe what you expected to happen. Reference screenshots are recommended.'
@@ -47,7 +47,7 @@ body:
       required: true
 
   - type: textarea
-    id: issue
+    id: instead
     attributes:
       label: 'What happened instead?'
       description: 'Describe how the conversion ended up looking. Screenshots are recommended.'

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -31,7 +31,7 @@ body:
       required: true
 
   - type: textarea
-    id: what
+    id: expect
     attributes:
       label: 'What happened?'
       description: 'Give us some details on what you were trying and what happened.'
@@ -39,7 +39,7 @@ body:
       required: true
 
   - type: textarea
-    id: issue
+    id: instead
     attributes:
       label: 'What were you expecting?'
       description: 'Describe what you expected to happen. Reference screenshots are recommended.'

--- a/.github/ISSUE_TEMPLATE/scene.yml
+++ b/.github/ISSUE_TEMPLATE/scene.yml
@@ -39,7 +39,7 @@ body:
       required: true
 
   - type: textarea
-    id: issue
+    id: expect
     attributes:
       label: 'What were you expecting?'
       description: 'Describe what you expected to happen. Reference screenshots are recommended.'
@@ -47,7 +47,7 @@ body:
       required: true
 
   - type: textarea
-    id: issue
+    id: instead
     attributes:
       label: 'What happened instead?'
       description: 'Describe how the conversion ended up looking. Screenshots are recommended.'


### PR DESCRIPTION
Due to an oversight, I forgot to add unique IDs to fields in certain templates.

This PR adds them.