### PR TITLE
feat: Create custom editor drawers for Resonite components

### DIFF
--- a/Assets/ResoniteSDK/Editor/Drawers.meta
+++ b/Assets/ResoniteSDK/Editor/Drawers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 78029ee0fa0ca994f98bffdb3c3a06fd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ResoniteSDK/Editor/Drawers/EditorDrawers.meta
+++ b/Assets/ResoniteSDK/Editor/Drawers/EditorDrawers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 12cddad20521f144f8c495f5418fe665
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ResoniteSDK/Editor/Drawers/EditorDrawers/ComponentEditor.cs
+++ b/Assets/ResoniteSDK/Editor/Drawers/EditorDrawers/ComponentEditor.cs
@@ -1,0 +1,29 @@
+﻿using UnityEditor;
+
+[CustomEditor(typeof(ResoniteComponent<>), true)]
+public class ComponentEditor : Editor
+{
+    public override void OnInspectorGUI()
+    {
+        // Update the displayed serialized data if it has changed
+        serializedObject.UpdateIfRequiredOrScript();
+
+        // Iterate the children of "Data"
+        SerializedProperty iterator = serializedObject.FindProperty("Data");
+
+        // Start drawing the children properties of Data
+        bool enterChildren = true;
+
+        // Iterate over each child and draw it
+        while (iterator.NextVisible(enterChildren))
+        {
+            // Draw the property field
+            EditorGUILayout.PropertyField(iterator, true);
+            // Prevent from iterating children of children of data
+            enterChildren = false;
+        }
+
+        // Apply any modified values from this draw
+        serializedObject.ApplyModifiedProperties();
+    }
+}

--- a/Assets/ResoniteSDK/Editor/Drawers/EditorDrawers/ComponentEditor.cs.meta
+++ b/Assets/ResoniteSDK/Editor/Drawers/EditorDrawers/ComponentEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0808c079e066fb0409cc6cabe054556a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers.meta
+++ b/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fff793044106b43458b69aee47e4e9bc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/AbstractFieldDrawer.cs
+++ b/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/AbstractFieldDrawer.cs
@@ -1,0 +1,76 @@
+using UnityEngine;
+using UnityEditor;
+
+public abstract class AbstractFieldDrawer : PropertyDrawer
+{
+
+    /// <summary>
+    /// The relative property path to the nested Data property
+    /// </summary>
+    /// <remarks>
+    /// For example Field has "Data" and Reference has "_data"
+    /// </remarks>
+    protected abstract string DataPropertyName { get; }
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        SerializedProperty dataProperty = property.FindPropertyRelative(DataPropertyName);
+        
+        // Get the raw field name without _Element
+        label.text = GetElementNiceName(property);
+
+        if (dataProperty != null)
+        {
+            // Call the implemented draw field method
+            DrawField(position, dataProperty, label, property);
+        }
+        // The data property is null if unity is unable to serialize that field type
+        else
+        {
+            //Debug.LogWarning($"Field {property.name} of type {property.type} is unserializable in unity.");
+            EditorGUI.LabelField(position, label, new GUIContent("Unserializable type"));
+        }
+    }
+
+    /// <summary>
+    /// Drop _Element from resonite field names.
+    /// </summary>
+    /// <param name="property">The property to get the name of.</param>
+    /// <returns>Resonite-like field names.</returns>
+    public static string GetElementNiceName(SerializedProperty property)
+    {
+        const string suffix = "_Element";
+
+        // Get the actual name instead of the unity DisplayName
+        string text = property.name;
+
+        // If it ends with _Element (it should) then we remove that suffix
+        if (text.EndsWith(suffix))
+        {
+            return text[..^suffix.Length];
+        }
+
+        return text;
+    }
+
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        SerializedProperty dataProperty = property.FindPropertyRelative(DataPropertyName);
+        
+        // Catch unserialized data property and return the default line height
+        if (dataProperty == null) {
+            return EditorGUIUtility.singleLineHeight;
+        }
+        
+        // Return the line height for that property type
+        return EditorGUI.GetPropertyHeight(dataProperty, true);
+    }
+
+    /// <summary>
+    /// The implemented field drawer for the data property.
+    /// </summary>
+    /// <inheritdoc cref="OnGUI(Rect, SerializedProperty, GUIContent)"/>
+    /// <param name="dataProperty">The nested data property field.</param>
+    /// <param name="originalProperty">The base property field.</param>
+    /// <returns>If this method has successfully drawn a field.</returns>
+    protected abstract bool DrawField(Rect position, SerializedProperty dataProperty, GUIContent label, SerializedProperty originalProperty);
+}

--- a/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/AbstractFieldDrawer.cs.meta
+++ b/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/AbstractFieldDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ebfbdae1cc3e354abf32b72eda8ea22
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/FieldDrawer.cs
+++ b/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/FieldDrawer.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+using UnityEditor;
+
+[CustomPropertyDrawer(typeof(Field<,>), true)]
+public class FieldDrawer : AbstractFieldDrawer
+{
+    protected override string DataPropertyName => "Data";
+
+    protected override bool DrawField(Rect position, SerializedProperty dataProperty, GUIContent label, SerializedProperty originalProperty)
+    {
+        return EditorGUI.PropertyField(position, dataProperty, label, true);
+    }
+}

--- a/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/FieldDrawer.cs.meta
+++ b/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/FieldDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e16f8163dff2c294dac31305b07b5c0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/ReferenceDrawer.cs
+++ b/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/ReferenceDrawer.cs
@@ -1,0 +1,19 @@
+using UnityEditor;
+using UnityEngine;
+
+[CustomPropertyDrawer(typeof(Reference<,>), true)]
+public class ReferenceDrawer : AbstractFieldDrawer
+{
+    protected override string DataPropertyName => "_data";
+
+    protected override bool DrawField(Rect position, SerializedProperty dataProperty, GUIContent label, SerializedProperty originalProperty)
+    {
+        // originalProperty.GetUnderlyingType() -> Gets the field's Reference<TReference, TData> type
+        
+        // Temporary label field while there is no GUI for references
+        EditorGUI.LabelField(position, label, new GUIContent("No GUI Implemented"));
+
+        // This 'field' will always draw so we always return true
+        return true;
+    }
+}

--- a/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/ReferenceDrawer.cs.meta
+++ b/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/ReferenceDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37a92f6efa29d614f976343e03bc5677
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/SyncListDrawer.cs
+++ b/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/SyncListDrawer.cs
@@ -1,0 +1,13 @@
+using UnityEditor;
+using UnityEngine;
+
+[CustomPropertyDrawer(typeof(SyncList<,>), true)]
+public class SyncListDrawer : AbstractFieldDrawer
+{
+    protected override string DataPropertyName => "Data";
+
+    protected override bool DrawField(Rect position, SerializedProperty dataProperty, GUIContent label, SerializedProperty originalProperty)
+    {
+        return EditorGUI.PropertyField(position, dataProperty, label);
+    }
+}

--- a/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/SyncListDrawer.cs.meta
+++ b/Assets/ResoniteSDK/Editor/Drawers/PropertyDrawers/SyncListDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db93e7970677ee24d888e0d9b8dce178
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Initial implementation of editor and property drawers for Resonite data
This is to remove the unneeded Component > Data > Properties > Data > Values layout


- References currently have no GUI
- Certain types are un-serializable by unity such as Uri, DateTime, Nullable<>
  - As far as I am aware this makes properties of those types un-editable without wrapping them in our own types
- For some reason (unity) `EditorGUI.GetPropertyHeight` returns the wrong size of Quaternions in Euler mode


<img width="806" height="692" alt="image" src="https://github.com/user-attachments/assets/f9bd7d6e-8998-4098-b084-5d9c0e673651" />
  
<img width="791" height="931" alt="image" src="https://github.com/user-attachments/assets/6d48c88f-ef3d-4e23-bf39-e79b728d0bcb" />


Partial implementation towards #14 