### PR TITLE
Fix skinned meshes not being detected correctly in some cases

### DIFF
--- a/Assets/ResoniteSDK/Editor/AssetConverters/MeshConverter.cs
+++ b/Assets/ResoniteSDK/Editor/AssetConverters/MeshConverter.cs
@@ -127,7 +127,9 @@ public class MeshConverter : AssetConverter<StaticMeshWrapper, StaticMesh, Unity
             data.BlendShapes.Add(blendshape);
         }
 
-        data.BoneWeightCount = mesh.HasVertexAttribute(UnityEngine.Rendering.VertexAttribute.BlendWeight) ? 4 : 0;
+        var hasBoneWeights = mesh.bindposeCount > 0;
+
+        data.BoneWeightCount = hasBoneWeights ? 4 : 0;
 
         // Convert the vertex data
         data.AllocateBuffer();


### PR DESCRIPTION
When converting skinned meshes, some of them would not be detected correctly and convert as static mesh instead, resulting in a mangled avatars.

Fixes https://github.com/Yellow-Dog-Man/Resonite.UnitySDK/issues/31