### PR TITLE
Add new fields in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/assets.yml
+++ b/.github/ISSUE_TEMPLATE/assets.yml
@@ -39,6 +39,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: mods-present
+    attributes:
+      label: 'I tested the issue **without** mods.'
+      description: 'Did you test the issue without any mods to make sure it is not caused by those.'
+      options:
+        - 'Yes'
+        - 'No'
+      default: 0
+    validations:
+      required: true
+
   - type: textarea
     id: what
     attributes:

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -39,6 +39,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: mods-present
+    attributes:
+      label: 'I tested the issue **without** mods.'
+      description: 'Did you test the issue without any mods to make sure it is not caused by those.'
+      options:
+        - 'Yes'
+        - 'No'
+      default: 0
+    validations:
+      required: true
+
   - type: textarea
     id: expect
     attributes:

--- a/.github/ISSUE_TEMPLATE/scene.yml
+++ b/.github/ISSUE_TEMPLATE/scene.yml
@@ -39,6 +39,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: mods-present
+    attributes:
+      label: 'I tested the issue **without** mods.'
+      description: 'Did you test the issue without any mods to make sure it is not caused by those.'
+      options:
+        - 'Yes'
+        - 'No'
+      default: 0
+    validations:
+      required: true
+
   - type: textarea
     id: what
     attributes:

--- a/.github/ISSUE_TEMPLATE/shader-mat.yml
+++ b/.github/ISSUE_TEMPLATE/shader-mat.yml
@@ -39,6 +39,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: mods-present
+    attributes:
+      label: 'I tested the issue **without** mods.'
+      description: 'Did you test the issue without any mods to make sure it is not caused by those.'
+      options:
+        - 'Yes'
+        - 'No'
+      default: 0
+    validations:
+      required: true
+
   - type: textarea
     id: what
     attributes:


### PR DESCRIPTION
Adds two new fields to issue templates:
- `version-resonite` which is the user's Resonite version.
- `mods-present` small dropdown asking users to make sure they did tests without mods.

Tried to *innovate* a tad with the mods section, what do you think @Frooxius?

Closes https://github.com/Yellow-Dog-Man/Resonite.UnitySDK/issues/36