### PR TITLE
Auto-add references when attaching BipedAvatarDescriptor

### DIFF
--- a/Assets/ResoniteSDK/Processors/Avatar/BipedAvatarDescriptor.cs
+++ b/Assets/ResoniteSDK/Processors/Avatar/BipedAvatarDescriptor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using UnityEngine;
 
+[ExecuteInEditMode]
 public class BipedAvatarDescriptor : MonoBehaviour, IConversionPostProcessor
 {
     const float EYE_SEPARATION = 0.065f; // 65 mm
@@ -29,6 +30,38 @@ public class BipedAvatarDescriptor : MonoBehaviour, IConversionPostProcessor
     public bool SetupEyes = true;
     public bool SetupFaceTracking = true;
     public bool SetupVolumeMeter = false;
+
+    [ExecuteInEditMode]
+    void Awake()
+    {
+        // If biped has already been assigned, do not run the auto setup
+        if (Biped != null)
+            return;
+
+        // Try to initialize the biped on attach
+        Biped = GetComponent<Animator>();
+
+        // Initialize references
+        if (ViewpointReference == null && LeftHandReference == null && RightHandReference == null)
+        {
+            var references = new GameObject("References");
+            references.transform.SetParent(transform, false);
+
+            var viewpoint = new GameObject("Viewpoint");
+            viewpoint.transform.SetParent(references.transform, false);
+            ViewpointReference = viewpoint.transform;
+
+            var leftHand = new GameObject("Left Hand");
+            leftHand.transform.SetParent(references.transform, false);
+            LeftHandReference = leftHand.transform;
+
+            var rightHand = new GameObject("Right Hand");
+            rightHand.transform.SetParent(references.transform, false);
+            RightHandReference = rightHand.transform;
+
+            // TODO!!! Try position the references automatically
+        }
+    }
 
     public void PostProcessConversion(IConversionContext context)
     {


### PR DESCRIPTION
Based on this: https://github.com/Yellow-Dog-Man/Resonite.UnitySDK/issues/41 and some other feedback, this automatically adds references when this is attached.

This should hopefully make this a bit easier. I plan to add some basic auto-positioning soon (if nobody takes it up first), but I want to push a release and I'm running out of time now, so this should hopefully suffice for now.