### PR TITLE
Avatar Setup Wizard 2

### DIFF
--- a/Assets/ResoniteSDK/AvatarSetup/Editor/ResoniteAvatarSetupWizard.cs
+++ b/Assets/ResoniteSDK/AvatarSetup/Editor/ResoniteAvatarSetupWizard.cs
@@ -526,11 +526,8 @@ public class ResoniteAvatarSetupWizard : EditorWindow
 
         var referencesParent = avatarDescriptor.EnsureReferencesExist();
         if (referencesParent != null)
-            avatarDescriptor.CreateOptionalReferenceSlots(referencesParent, _useGlobalOrientation);
-
-        avatarDescriptor.RepositionOptionalReference(avatarDescriptor.LeftFootReference, _leftFootOverride);
-        avatarDescriptor.RepositionOptionalReference(avatarDescriptor.RightFootReference, _rightFootOverride);
-        avatarDescriptor.RepositionOptionalReference(avatarDescriptor.HipsReference, _hipsOverride);
+            avatarDescriptor.CreateOptionalReferenceSlots(referencesParent, _useGlobalOrientation,
+                _leftFootOverride, _rightFootOverride, _hipsOverride);
 
         TrackCreatedReferenceHierarchy(setupTracker, avatarDescriptor);
 

--- a/Assets/ResoniteSDK/AvatarSetup/Editor/ResoniteAvatarSetupWizard.cs
+++ b/Assets/ResoniteSDK/AvatarSetup/Editor/ResoniteAvatarSetupWizard.cs
@@ -252,11 +252,10 @@ public class ResoniteAvatarSetupWizard : EditorWindow
             return;
         }
 
-        if (avatarDescriptor != null)
-            EditorGUILayout.HelpBox("ResoniteBipedAvatarDescriptor already present. Setup will reconfigure it.", MessageType.Info);
-
         if (setupTracker != null)
-            EditorGUILayout.HelpBox("Previous wizard setup detected. Use Revert to undo, or Setup to reconfigure.", MessageType.Info);
+            EditorGUILayout.HelpBox("Previous setup detected. Use Revert to undo, or Setup to reconfigure.", MessageType.Info);
+        else if (avatarDescriptor != null)
+            EditorGUILayout.HelpBox("ResoniteBipedAvatarDescriptor already present. Setup will reconfigure it.", MessageType.Info);
     }
 
     void DrawDetectedBonesSection(Animator humanoidAnimator)

--- a/Assets/ResoniteSDK/AvatarSetup/Editor/ResoniteAvatarSetupWizard.cs
+++ b/Assets/ResoniteSDK/AvatarSetup/Editor/ResoniteAvatarSetupWizard.cs
@@ -429,10 +429,8 @@ public class ResoniteAvatarSetupWizard : EditorWindow
                 Undo.SetCurrentGroupName("Try Auto Setup Tool Anchors");
                 int undoGroup = Undo.GetCurrentGroup();
 
-                if (avatarDescriptor.LeftHandReference != null)
-                    Undo.RecordObject(avatarDescriptor.LeftHandReference, "Position Left Tool Anchors");
-                if (avatarDescriptor.RightHandReference != null)
-                    Undo.RecordObject(avatarDescriptor.RightHandReference, "Position Right Tool Anchors");
+                RecordHandAnchorChildrenForUndo(avatarDescriptor.LeftHandReference);
+                RecordHandAnchorChildrenForUndo(avatarDescriptor.RightHandReference);
 
                 avatarDescriptor.TryAutoPositionToolAnchors();
 
@@ -650,6 +648,20 @@ public class ResoniteAvatarSetupWizard : EditorWindow
         var boneTransform = humanoidAnimator.GetBoneTransform(bone);
         string boneName = boneTransform != null ? boneTransform.name : "(not found)";
         EditorGUILayout.LabelField(label, boneName);
+    }
+
+    void RecordHandAnchorChildrenForUndo(Transform handReference)
+    {
+        if (handReference == null)
+            return;
+
+        var tooltip = handReference.Find("Tooltip");
+        var grabber = handReference.Find("Grabber");
+        var shelf = handReference.Find("Shelf");
+
+        if (tooltip != null) Undo.RecordObject(tooltip, "Position Tool Anchors");
+        if (grabber != null) Undo.RecordObject(grabber, "Position Tool Anchors");
+        if (shelf != null) Undo.RecordObject(shelf, "Position Tool Anchors");
     }
 
     void DrawOptionalRefWithAutoDetect(Animator humanoidAnimator, string label, ref Transform field, HumanBodyBones bone)

--- a/Assets/ResoniteSDK/AvatarSetup/Editor/ResoniteAvatarSetupWizard.cs
+++ b/Assets/ResoniteSDK/AvatarSetup/Editor/ResoniteAvatarSetupWizard.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using UnityEditor;
 using UnityEditor.SceneManagement;
@@ -15,7 +16,9 @@ public class ResoniteAvatarSetupWizard : EditorWindow
     [SerializeField] Transform _hipsOverride;
     [SerializeField] Vector3 _viewpointOffset;
     [SerializeField] Vector2 _scrollPosition;
+    [SerializeField] bool _useGlobalOrientation;
     [SerializeField] bool _showOptionalRefs;
+    [SerializeField] bool _showRotationTools;
     [SerializeField] bool _showEditVisuals = true;
     [SerializeField] bool _showViewpointVisual = true;
     [SerializeField] bool _showLeftFootVisual = true;
@@ -30,19 +33,12 @@ public class ResoniteAvatarSetupWizard : EditorWindow
     {
         var window = GetWindow<ResoniteAvatarSetupWizard>();
         window.titleContent = new GUIContent("Avatar Setup Wizard");
-        window.minSize = new Vector2(400, 500);
+        window.minSize = new Vector2(420, 500);
         window.Show();
     }
 
-    void OnEnable()
-    {
-        SceneView.duringSceneGui += OnSceneGUI;
-    }
-
-    void OnDisable()
-    {
-        SceneView.duringSceneGui -= OnSceneGUI;
-    }
+    void OnEnable() => SceneView.duringSceneGui += OnSceneGUI;
+    void OnDisable() => SceneView.duringSceneGui -= OnSceneGUI;
 
     void OnGUI()
     {
@@ -61,17 +57,31 @@ public class ResoniteAvatarSetupWizard : EditorWindow
         {
             DrawDetectedBonesSection(humanoidAnimator);
             DrawViewpointSection(avatarDescriptor);
-            DrawOptionalReferencesSection(humanoidAnimator);
             DrawSetupOptionsSection();
-            DrawToolAnchorSection(avatarDescriptor);
+
+            EditorGUILayout.Space(6);
+            DrawActionButtons(hasValidAnimator, setupTracker, avatarDescriptor);
+            EditorGUILayout.Space(6);
+
+            DrawSeparator();
+            DrawOptionalReferencesSection(humanoidAnimator);
+            DrawRotationToolsSection(avatarDescriptor);
+
+            DrawSeparator();
             DrawEditVisualsSection();
         }
-
-        EditorGUILayout.Space(10);
-        DrawActionButtons(hasValidAnimator, setupTracker, avatarDescriptor);
+        else
+        {
+            EditorGUILayout.Space(10);
+            DrawActionButtons(hasValidAnimator, setupTracker, avatarDescriptor);
+        }
 
         EditorGUILayout.EndScrollView();
     }
+
+    // ─────────────────────────────────────────────
+    //  Scene Gizmos
+    // ─────────────────────────────────────────────
 
     void OnSceneGUI(SceneView sceneView)
     {
@@ -206,6 +216,10 @@ public class ResoniteAvatarSetupWizard : EditorWindow
         Handles.DrawLine(position, position + rotation * Vector3.right * length);
     }
 
+    // ─────────────────────────────────────────────
+    //  UI Sections
+    // ─────────────────────────────────────────────
+
     void DrawAvatarRootSection()
     {
         EditorGUILayout.LabelField("Avatar Root", EditorStyles.boldLabel);
@@ -239,7 +253,7 @@ public class ResoniteAvatarSetupWizard : EditorWindow
         }
 
         if (avatarDescriptor != null)
-            EditorGUILayout.HelpBox("BipedAvatarDescriptor already present. Setup will reconfigure it.", MessageType.Info);
+            EditorGUILayout.HelpBox("ResoniteBipedAvatarDescriptor already present. Setup will reconfigure it.", MessageType.Info);
 
         if (setupTracker != null)
             EditorGUILayout.HelpBox("Previous wizard setup detected. Use Revert to undo, or Setup to reconfigure.", MessageType.Info);
@@ -257,8 +271,8 @@ public class ResoniteAvatarSetupWizard : EditorWindow
 
             var leftEyeBone = humanoidAnimator.GetBoneTransform(HumanBodyBones.LeftEye);
             var rightEyeBone = humanoidAnimator.GetBoneTransform(HumanBodyBones.RightEye);
-            string eyeDetectionStatus = (leftEyeBone != null && rightEyeBone != null) ? "Detected" : "Not found (will estimate)";
-            EditorGUILayout.LabelField("Eyes", eyeDetectionStatus);
+            string eyeStatus = (leftEyeBone != null && rightEyeBone != null) ? "Detected" : "Not found (will estimate)";
+            EditorGUILayout.LabelField("Eyes", eyeStatus);
         }
 
         EditorGUILayout.Space(4);
@@ -279,39 +293,18 @@ public class ResoniteAvatarSetupWizard : EditorWindow
                 _viewpointOffset = editedLocalPosition;
             }
 
-            EditorGUILayout.BeginHorizontal();
             using (new EditorGUI.DisabledScope(true))
                 EditorGUILayout.Vector3Field("World Position", avatarDescriptor.ViewpointReference.position);
-            EditorGUILayout.EndHorizontal();
 
             EditorGUILayout.HelpBox("Drag the position handle in the Scene View to adjust the viewpoint.", MessageType.None);
         }
         else
         {
             _viewpointOffset = EditorGUILayout.Vector3Field("Offset (applied on Setup)", _viewpointOffset);
-
-            EditorGUILayout.BeginHorizontal();
             if (GUILayout.Button("Reset Offset", GUILayout.Width(100)))
                 _viewpointOffset = Vector3.zero;
-            EditorGUILayout.EndHorizontal();
         }
 
-        EditorGUILayout.Space(4);
-    }
-
-    void DrawOptionalReferencesSection(Animator humanoidAnimator)
-    {
-        _showOptionalRefs = EditorGUILayout.Foldout(_showOptionalRefs, "Optional References", true, EditorStyles.foldoutHeader);
-        if (!_showOptionalRefs)
-            return;
-
-        EditorGUI.indentLevel++;
-
-        DrawOptionalRefWithAutoDetect(humanoidAnimator, "Left Foot", ref _leftFootOverride, HumanBodyBones.LeftFoot);
-        DrawOptionalRefWithAutoDetect(humanoidAnimator, "Right Foot", ref _rightFootOverride, HumanBodyBones.RightFoot);
-        DrawOptionalRefWithAutoDetect(humanoidAnimator, "Hips", ref _hipsOverride, HumanBodyBones.Hips);
-
-        EditorGUI.indentLevel--;
         EditorGUILayout.Space(4);
     }
 
@@ -323,35 +316,155 @@ public class ResoniteAvatarSetupWizard : EditorWindow
         _setupEyes = EditorGUILayout.Toggle("Eye Setup", _setupEyes);
         _setupFaceTracking = EditorGUILayout.Toggle("Face Tracking", _setupFaceTracking);
         _setupVolumeMeter = EditorGUILayout.Toggle("Volume Meter", _setupVolumeMeter);
+        _useGlobalOrientation = EditorGUILayout.Toggle("Use Global Forward/Up", _useGlobalOrientation);
+
+        if (!_useGlobalOrientation && _avatarRoot != null && RootDeviatesFromGlobal())
+            EditorGUILayout.HelpBox("Root forward/up differs from global. Enable this if hips or feet are rotated incorrectly.", MessageType.Warning);
+
+        EditorGUILayout.Space(2);
+    }
+
+    void DrawActionButtons(bool hasValidAnimator, AvatarSetupTracker setupTracker, ResoniteBipedAvatarDescriptor avatarDescriptor)
+    {
+        EditorGUILayout.BeginHorizontal();
+
+        GUI.enabled = hasValidAnimator;
+        if (GUILayout.Button("Setup Avatar", GUILayout.Height(30)))
+            PerformSetup();
+
+        GUI.enabled = setupTracker != null;
+        if (GUILayout.Button("Revert Setup", GUILayout.Height(30)))
+            PerformRevert();
+
+        GUI.enabled = true;
+        EditorGUILayout.EndHorizontal();
+    }
+
+    void DrawOptionalReferencesSection(Animator humanoidAnimator)
+    {
+        _showOptionalRefs = EditorGUILayout.Foldout(_showOptionalRefs, "Optional References", true, EditorStyles.foldoutHeader);
+        if (!_showOptionalRefs)
+            return;
+
+        EditorGUI.indentLevel++;
+        DrawOptionalRefWithAutoDetect(humanoidAnimator, "Left Foot", ref _leftFootOverride, HumanBodyBones.LeftFoot);
+        DrawOptionalRefWithAutoDetect(humanoidAnimator, "Right Foot", ref _rightFootOverride, HumanBodyBones.RightFoot);
+        DrawOptionalRefWithAutoDetect(humanoidAnimator, "Hips", ref _hipsOverride, HumanBodyBones.Hips);
+        EditorGUI.indentLevel--;
 
         EditorGUILayout.Space(4);
     }
 
-    void DrawToolAnchorSection(ResoniteBipedAvatarDescriptor avatarDescriptor)
+    void DrawRotationToolsSection(ResoniteBipedAvatarDescriptor avatarDescriptor)
     {
-        if (avatarDescriptor == null) return;
-        if (avatarDescriptor.LeftHandReference == null && avatarDescriptor.RightHandReference == null) return;
+        if (avatarDescriptor == null)
+            return;
 
-        EditorGUILayout.LabelField("Tool Anchors", EditorStyles.boldLabel);
+        bool hasAnyRef = avatarDescriptor.LeftFootReference != null
+            || avatarDescriptor.RightFootReference != null
+            || avatarDescriptor.HipsReference != null
+            || avatarDescriptor.LeftHandReference != null
+            || avatarDescriptor.RightHandReference != null;
 
-        if (GUILayout.Button("Try Auto Setup Tool Anchors"))
+        if (!hasAnyRef)
+            return;
+
+        _showRotationTools = EditorGUILayout.Foldout(_showRotationTools, "Tools", true, EditorStyles.foldoutHeader);
+        if (!_showRotationTools)
+            return;
+
+        EditorGUI.indentLevel++;
+
+        if (avatarDescriptor.LeftFootReference != null || avatarDescriptor.RightFootReference != null)
         {
-            Undo.SetCurrentGroupName("Try Auto Setup Tool Anchors");
-            int undoGroup = Undo.GetCurrentGroup();
+            EditorGUILayout.LabelField("Feet", EditorStyles.miniBoldLabel);
 
-            if (avatarDescriptor.LeftHandReference != null)
-                Undo.RecordObject(avatarDescriptor.LeftHandReference, "Position Left Tool Anchors");
-            if (avatarDescriptor.RightHandReference != null)
-                Undo.RecordObject(avatarDescriptor.RightHandReference, "Position Right Tool Anchors");
+            EditorGUILayout.BeginHorizontal();
+            DrawSmallFixButton("Fix Left (Toes)", avatarDescriptor.LeftFootReference,
+                () => avatarDescriptor.TryFixFootRotation(false));
+            DrawSmallFixButton("Fix Right (Toes)", avatarDescriptor.RightFootReference,
+                () => avatarDescriptor.TryFixFootRotation(true));
+            EditorGUILayout.EndHorizontal();
 
-            avatarDescriptor.TryAutoPositionToolAnchors();
+            EditorGUILayout.BeginHorizontal();
+            DrawSmallFixButton("Mirror L \u2192 R", avatarDescriptor.RightFootReference,
+                () => avatarDescriptor.MirrorRotation(avatarDescriptor.LeftFootReference, avatarDescriptor.RightFootReference, 1));
+            DrawSmallFixButton("Mirror R \u2192 L", avatarDescriptor.LeftFootReference,
+                () => avatarDescriptor.MirrorRotation(avatarDescriptor.RightFootReference, avatarDescriptor.LeftFootReference, 1));
+            EditorGUILayout.EndHorizontal();
 
-            Undo.CollapseUndoOperations(undoGroup);
-            EditorSceneManager.MarkSceneDirty(_avatarRoot.scene);
-            SceneView.RepaintAll();
+            EditorGUILayout.BeginHorizontal();
+            DrawSmallFixButton("Compute Left", avatarDescriptor.LeftFootReference,
+                () => avatarDescriptor.RecomputeFootReference(false, _useGlobalOrientation));
+            DrawSmallFixButton("Compute Right", avatarDescriptor.RightFootReference,
+                () => avatarDescriptor.RecomputeFootReference(true, _useGlobalOrientation));
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.Space(4);
         }
 
-        EditorGUILayout.Space(4);
+        if (avatarDescriptor.HipsReference != null)
+        {
+            EditorGUILayout.LabelField("Hips", EditorStyles.miniBoldLabel);
+
+            EditorGUILayout.BeginHorizontal();
+            DrawSmallFixButton("Fix (Tail)", avatarDescriptor.HipsReference,
+                () => avatarDescriptor.TryFixHipsRotation());
+            DrawSmallFixButton("Fix (Belly)", avatarDescriptor.HipsReference,
+                () => avatarDescriptor.TryFixHipsRotationFromBelly());
+            EditorGUILayout.EndHorizontal();
+
+            DrawSmallFixButton("Compute Hips", avatarDescriptor.HipsReference,
+                () => avatarDescriptor.RecomputeHipsReference(_useGlobalOrientation));
+
+            EditorGUILayout.Space(4);
+        }
+
+        if (avatarDescriptor.LeftHandReference != null || avatarDescriptor.RightHandReference != null)
+        {
+            EditorGUILayout.LabelField("Tool Anchors", EditorStyles.miniBoldLabel);
+
+            if (GUILayout.Button("Try Auto Setup Tool Anchors", GUILayout.Height(22)))
+            {
+                Undo.SetCurrentGroupName("Try Auto Setup Tool Anchors");
+                int undoGroup = Undo.GetCurrentGroup();
+
+                if (avatarDescriptor.LeftHandReference != null)
+                    Undo.RecordObject(avatarDescriptor.LeftHandReference, "Position Left Tool Anchors");
+                if (avatarDescriptor.RightHandReference != null)
+                    Undo.RecordObject(avatarDescriptor.RightHandReference, "Position Right Tool Anchors");
+
+                avatarDescriptor.TryAutoPositionToolAnchors();
+
+                Undo.CollapseUndoOperations(undoGroup);
+                EditorSceneManager.MarkSceneDirty(_avatarRoot.scene);
+                SceneView.RepaintAll();
+            }
+
+            EditorGUILayout.Space(4);
+        }
+
+        EditorGUI.indentLevel--;
+    }
+
+    void DrawSmallFixButton(string label, Transform referenceSlot, Func<bool> fixAction)
+    {
+        GUI.enabled = referenceSlot != null;
+        if (GUILayout.Button(label, GUILayout.Height(22)))
+        {
+            Undo.RecordObject(referenceSlot, label);
+            if (!fixAction())
+            {
+                Debug.LogWarning($"[Avatar Setup Wizard] {label}: no suitable bone data found.");
+            }
+            else
+            {
+                EditorUtility.SetDirty(referenceSlot);
+                EditorSceneManager.MarkSceneDirty(referenceSlot.gameObject.scene);
+                SceneView.RepaintAll();
+            }
+        }
+        GUI.enabled = true;
     }
 
     void DrawEditVisualsSection()
@@ -378,21 +491,9 @@ public class ResoniteAvatarSetupWizard : EditorWindow
         EditorGUILayout.Space(4);
     }
 
-    void DrawActionButtons(bool hasValidAnimator, AvatarSetupTracker setupTracker, ResoniteBipedAvatarDescriptor avatarDescriptor)
-    {
-        EditorGUILayout.BeginHorizontal();
-
-        GUI.enabled = hasValidAnimator;
-        if (GUILayout.Button("Setup Avatar", GUILayout.Height(32)))
-            PerformSetup();
-
-        GUI.enabled = setupTracker != null;
-        if (GUILayout.Button("Revert Setup", GUILayout.Height(32)))
-            PerformRevert();
-
-        GUI.enabled = true;
-        EditorGUILayout.EndHorizontal();
-    }
+    // ─────────────────────────────────────────────
+    //  Setup / Revert
+    // ─────────────────────────────────────────────
 
     void PerformSetup()
     {
@@ -415,7 +516,7 @@ public class ResoniteAvatarSetupWizard : EditorWindow
         }
         else
         {
-            Undo.RecordObject(avatarDescriptor, "Reconfigure BipedAvatarDescriptor");
+            Undo.RecordObject(avatarDescriptor, "Reconfigure ResoniteBipedAvatarDescriptor");
         }
 
         avatarDescriptor.SetupProtection = _setupProtection;
@@ -423,12 +524,15 @@ public class ResoniteAvatarSetupWizard : EditorWindow
         avatarDescriptor.SetupFaceTracking = _setupFaceTracking;
         avatarDescriptor.SetupVolumeMeter = _setupVolumeMeter;
 
+        var referencesParent = avatarDescriptor.EnsureReferencesExist();
+        if (referencesParent != null)
+            avatarDescriptor.CreateOptionalReferenceSlots(referencesParent, _useGlobalOrientation);
+
         avatarDescriptor.RepositionOptionalReference(avatarDescriptor.LeftFootReference, _leftFootOverride);
         avatarDescriptor.RepositionOptionalReference(avatarDescriptor.RightFootReference, _rightFootOverride);
         avatarDescriptor.RepositionOptionalReference(avatarDescriptor.HipsReference, _hipsOverride);
 
-        if (isNewDescriptor)
-            TrackCreatedReferenceHierarchy(setupTracker, avatarDescriptor);
+        TrackCreatedReferenceHierarchy(setupTracker, avatarDescriptor);
 
         if (avatarDescriptor.ViewpointReference != null && _viewpointOffset != Vector3.zero)
         {
@@ -491,6 +595,10 @@ public class ResoniteAvatarSetupWizard : EditorWindow
         SceneView.RepaintAll();
     }
 
+    // ─────────────────────────────────────────────
+    //  Helpers
+    // ─────────────────────────────────────────────
+
     Animator GetValidHumanoidAnimator()
     {
         if (_avatarRoot == null)
@@ -510,6 +618,34 @@ public class ResoniteAvatarSetupWizard : EditorWindow
 
         // Reset the viewpoint offset, to prevent offset from previous avatar being applied
         _viewpointOffset = Vector3.zero;
+        _leftFootOverride = null;
+        _rightFootOverride = null;
+        _hipsOverride = null;
+
+        var existingDescriptor = _avatarRoot.GetComponent<ResoniteBipedAvatarDescriptor>();
+        if (existingDescriptor != null)
+        {
+            _setupProtection = existingDescriptor.SetupProtection;
+            _setupEyes = existingDescriptor.SetupEyes;
+            _setupFaceTracking = existingDescriptor.SetupFaceTracking;
+            _setupVolumeMeter = existingDescriptor.SetupVolumeMeter;
+        }
+    }
+
+    bool RootDeviatesFromGlobal()
+    {
+        var rootRotation = _avatarRoot.transform.rotation;
+        float forwardDot = Vector3.Dot(rootRotation * Vector3.forward, Vector3.forward);
+        float upDot = Vector3.Dot(rootRotation * Vector3.up, Vector3.up);
+        return forwardDot < 0.99f || upDot < 0.99f;
+    }
+
+    void DrawSeparator()
+    {
+        EditorGUILayout.Space(2);
+        var rect = EditorGUILayout.GetControlRect(false, 1);
+        EditorGUI.DrawRect(rect, new Color(0.5f, 0.5f, 0.5f, 0.3f));
+        EditorGUILayout.Space(2);
     }
 
     void DrawBoneField(Animator humanoidAnimator, string label, HumanBodyBones bone)

--- a/Assets/ResoniteSDK/Processors/Avatar/ResoniteBipedAvatarDescriptor.cs
+++ b/Assets/ResoniteSDK/Processors/Avatar/ResoniteBipedAvatarDescriptor.cs
@@ -32,7 +32,6 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
     public bool SetupFaceTracking = true;
     public bool SetupVolumeMeter = false;
 
-    [ExecuteInEditMode]
     void Awake()
     {
         if (Biped != null)
@@ -599,9 +598,9 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
         var rightFootSlot = RightFootReference != null ? RightFootReference.GetSlot() : null;
         var hipsSlot = HipsReference != null ? HipsReference.GetSlot() : null;
 
-        if (leftFootSlot == null) Debug.LogWarning("[ResoniteBipedAvatarDescriptor] PostProcessConversion: LeftFootReference is null, skipping left foot slot.");
-        if (rightFootSlot == null) Debug.LogWarning("[ResoniteBipedAvatarDescriptor] PostProcessConversion: RightFootReference is null, skipping right foot slot.");
-        if (hipsSlot == null) Debug.LogWarning("[ResoniteBipedAvatarDescriptor] PostProcessConversion: HipsReference is null, skipping hips slot.");
+        if (leftFootSlot == null) Debug.Log("[ResoniteBipedAvatarDescriptor] No left foot reference provided, skipping.");
+        if (rightFootSlot == null) Debug.Log("[ResoniteBipedAvatarDescriptor] No right foot reference provided, skipping.");
+        if (hipsSlot == null) Debug.Log("[ResoniteBipedAvatarDescriptor] No hips reference provided, skipping.");
 
         Task.Run(async () =>
         {

--- a/Assets/ResoniteSDK/Processors/Avatar/ResoniteBipedAvatarDescriptor.cs
+++ b/Assets/ResoniteSDK/Processors/Avatar/ResoniteBipedAvatarDescriptor.cs
@@ -81,7 +81,8 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
         return references.transform;
     }
 
-    public void CreateOptionalReferenceSlots(Transform referencesParent, bool useGlobalOrientation = false)
+    public void CreateOptionalReferenceSlots(Transform referencesParent, bool useGlobalOrientation,
+        Transform leftFootOverride = null, Transform rightFootOverride = null, Transform hipsOverride = null)
     {
         if (referencesParent == null)
         {
@@ -94,28 +95,31 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
 
         var avatarRootRotation = useGlobalOrientation ? Quaternion.identity : transform.rotation;
 
-        if (LeftFootReference == null)
+        if (leftFootOverride != null && LeftFootReference == null)
         {
             var leftFoot = new GameObject("Left Foot");
             leftFoot.transform.SetParent(referencesParent, false);
             LeftFootReference = leftFoot.transform;
             PositionReferenceAtBone(LeftFootReference, HumanBodyBones.LeftFoot, avatarRootRotation);
+            RepositionOptionalReference(LeftFootReference, leftFootOverride);
         }
 
-        if (RightFootReference == null)
+        if (rightFootOverride != null && RightFootReference == null)
         {
             var rightFoot = new GameObject("Right Foot");
             rightFoot.transform.SetParent(referencesParent, false);
             RightFootReference = rightFoot.transform;
             PositionReferenceAtBone(RightFootReference, HumanBodyBones.RightFoot, avatarRootRotation);
+            RepositionOptionalReference(RightFootReference, rightFootOverride);
         }
 
-        if (HipsReference == null)
+        if (hipsOverride != null && HipsReference == null)
         {
             var hips = new GameObject("Hips");
             hips.transform.SetParent(referencesParent, false);
             HipsReference = hips.transform;
             PositionReferenceAtBone(HipsReference, HumanBodyBones.Hips, avatarRootRotation);
+            RepositionOptionalReference(HipsReference, hipsOverride);
         }
     }
 

--- a/Assets/ResoniteSDK/Processors/Avatar/ResoniteBipedAvatarDescriptor.cs
+++ b/Assets/ResoniteSDK/Processors/Avatar/ResoniteBipedAvatarDescriptor.cs
@@ -594,9 +594,9 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
         var leftHandSlot = LeftHandReference.GetSlot();
         var rightHandSlot = RightHandReference.GetSlot();
 
-        var leftFootSlot = LeftFootReference != null ? LeftFootReference.GetSlot() : null;
-        var rightFootSlot = RightFootReference != null ? RightFootReference.GetSlot() : null;
-        var hipsSlot = HipsReference != null ? HipsReference.GetSlot() : null;
+        var leftFootSlot = LeftFootReference.GetSlot();
+        var rightFootSlot = RightFootReference.GetSlot();
+        var hipsSlot = HipsReference.GetSlot();
 
         if (leftFootSlot == null) Debug.Log("[ResoniteBipedAvatarDescriptor] No left foot reference provided, skipping.");
         if (rightFootSlot == null) Debug.Log("[ResoniteBipedAvatarDescriptor] No right foot reference provided, skipping.");

--- a/Assets/ResoniteSDK/Processors/Avatar/ResoniteBipedAvatarDescriptor.cs
+++ b/Assets/ResoniteSDK/Processors/Avatar/ResoniteBipedAvatarDescriptor.cs
@@ -47,6 +47,8 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
         {
             var references = new GameObject("References");
             references.transform.SetParent(transform, false);
+            references.transform.localPosition = Vector3.zero;
+            references.transform.localRotation = Quaternion.identity;
 
             var viewpoint = new GameObject("Viewpoint");
             viewpoint.transform.SetParent(references.transform, false);
@@ -68,27 +70,65 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
         }
     }
 
-    void CreateOptionalReferenceSlots(Transform referencesParent)
+    public Transform EnsureReferencesExist()
     {
+        if (Biped == null)
+            Biped = GetComponent<Animator>();
+
+        if (ViewpointReference != null && LeftHandReference != null && RightHandReference != null)
+            return ViewpointReference.parent;
+
+        var existingRefs = transform.Find("References");
+        if (existingRefs != null)
+            DestroyImmediate(existingRefs.gameObject);
+
+        var references = new GameObject("References");
+        references.transform.SetParent(transform, false);
+        references.transform.localPosition = Vector3.zero;
+        references.transform.localRotation = Quaternion.identity;
+
+        var viewpoint = new GameObject("Viewpoint");
+        viewpoint.transform.SetParent(references.transform, false);
+        ViewpointReference = viewpoint.transform;
+
+        var leftHand = new GameObject("Left Hand");
+        leftHand.transform.SetParent(references.transform, false);
+        LeftHandReference = leftHand.transform;
+        SetupAnchors(LeftHandReference);
+
+        var rightHand = new GameObject("Right Hand");
+        rightHand.transform.SetParent(references.transform, false);
+        RightHandReference = rightHand.transform;
+        SetupAnchors(RightHandReference);
+
+        LeftFootReference = null;
+        RightFootReference = null;
+        HipsReference = null;
+
+        TryPositionReferences();
+
+        return references.transform;
+    }
+
+    public void CreateOptionalReferenceSlots(Transform referencesParent, bool useGlobalOrientation = false)
+    {
+        if (referencesParent == null)
+        {
+            Debug.LogWarning("[ResoniteBipedAvatarDescriptor] CreateOptionalReferenceSlots: referencesParent is null.");
+            return;
+        }
+
         if (Biped == null || Biped.avatar == null || !Biped.avatar.isHuman)
             return;
 
-        // TODO!!! This is currently not used, because the computation is wrong for most avatars
-        // The references need to have the Z axis be actual forward, but they just take the transform of the bone
-        // which is not guaranteed to have Z be actual forward
-        // The purpose of the referecens is to tell the system what the actual alignment of the bone is, so using
-        // the bone alignment works if and only if the bone is already perfectly aligned
-        // This needs to be reworked to actually compute the directions and then compute proper alignment from that
-
-        var skeletonUp = ComputeSkeletonUp();
-        var skeletonForward = ComputeSkeletonForward(skeletonUp);
+        var avatarRootRotation = useGlobalOrientation ? Quaternion.identity : transform.rotation;
 
         if (LeftFootReference == null)
         {
             var leftFoot = new GameObject("Left Foot");
             leftFoot.transform.SetParent(referencesParent, false);
             LeftFootReference = leftFoot.transform;
-            AlignReferenceSlotToSkeleton(LeftFootReference, HumanBodyBones.LeftFoot, skeletonUp, skeletonForward);
+            PositionReferenceAtBone(LeftFootReference, HumanBodyBones.LeftFoot, avatarRootRotation);
         }
 
         if (RightFootReference == null)
@@ -96,7 +136,7 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
             var rightFoot = new GameObject("Right Foot");
             rightFoot.transform.SetParent(referencesParent, false);
             RightFootReference = rightFoot.transform;
-            AlignReferenceSlotToSkeleton(RightFootReference, HumanBodyBones.RightFoot, skeletonUp, skeletonForward);
+            PositionReferenceAtBone(RightFootReference, HumanBodyBones.RightFoot, avatarRootRotation);
         }
 
         if (HipsReference == null)
@@ -104,55 +144,197 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
             var hips = new GameObject("Hips");
             hips.transform.SetParent(referencesParent, false);
             HipsReference = hips.transform;
-            AlignReferenceSlotToSkeleton(HipsReference, HumanBodyBones.Hips, skeletonUp, skeletonForward);
+            PositionReferenceAtBone(HipsReference, HumanBodyBones.Hips, avatarRootRotation);
         }
     }
 
-    Vector3 ComputeSkeletonUp()
+    void PositionReferenceAtBone(Transform referenceSlot, HumanBodyBones bone, Quaternion avatarRootRotation)
     {
-        var hipsBone = Biped.GetBoneTransform(HumanBodyBones.Hips);
-        var spineBone = Biped.GetBoneTransform(HumanBodyBones.Spine);
-
-        if (hipsBone != null && spineBone != null)
-            return (spineBone.position - hipsBone.position).normalized;
-
-        return Vector3.up;
-    }
-
-    Vector3 ComputeSkeletonForward(Vector3 skeletonUp)
-    {
-        var headBone = Biped.GetBoneTransform(HumanBodyBones.Head);
-        if (headBone == null)
-            return Vector3.forward;
-
-        var leftEye = Biped.GetBoneTransform(HumanBodyBones.LeftEye);
-        var rightEye = Biped.GetBoneTransform(HumanBodyBones.RightEye);
-
-        Vector3 headForward;
-        if (leftEye != null && rightEye != null)
+        if (referenceSlot == null)
         {
-            var averageEyePosition = (leftEye.position + rightEye.position) * 0.5f;
-            headForward = averageEyePosition - headBone.position;
-        }
-        else
-        {
-            headForward = headBone.forward;
+            Debug.LogWarning($"[ResoniteBipedAvatarDescriptor] PositionReferenceAtBone: referenceSlot is null for {bone}.");
+            return;
         }
 
-        var flattenedForward = Vector3.ProjectOnPlane(headForward, skeletonUp).normalized;
-        if (flattenedForward.sqrMagnitude < 0.001f)
-            return Vector3.forward;
-
-        return flattenedForward;
-    }
-
-    void AlignReferenceSlotToSkeleton(Transform referenceSlot, HumanBodyBones bone, Vector3 skeletonUp, Vector3 skeletonForward)
-    {
         var boneTransform = Biped.GetBoneTransform(bone);
         if (boneTransform == null) return;
 
         referenceSlot.position = boneTransform.position;
-        referenceSlot.rotation = Quaternion.LookRotation(skeletonForward, skeletonUp);
+        referenceSlot.rotation = avatarRootRotation;
+    }
+
+    public bool RecomputeFootReference(bool isRightFoot, bool useGlobalOrientation = false)
+    {
+        var footReference = isRightFoot ? RightFootReference : LeftFootReference;
+        if (footReference == null)
+        {
+            Debug.LogWarning($"[ResoniteBipedAvatarDescriptor] RecomputeFootReference: {(isRightFoot ? "Right" : "Left")}FootReference is null.");
+            return false;
+        }
+
+        if (Biped == null)
+        {
+            Debug.LogWarning("[ResoniteBipedAvatarDescriptor] RecomputeFootReference: Biped is null.");
+            return false;
+        }
+
+        var rotation = useGlobalOrientation ? Quaternion.identity : transform.rotation;
+        PositionReferenceAtBone(footReference, isRightFoot ? HumanBodyBones.RightFoot : HumanBodyBones.LeftFoot, rotation);
+        return true;
+    }
+
+    public bool RecomputeHipsReference(bool useGlobalOrientation = false)
+    {
+        if (HipsReference == null)
+        {
+            Debug.LogWarning("[ResoniteBipedAvatarDescriptor] RecomputeHipsReference: HipsReference is null.");
+            return false;
+        }
+
+        if (Biped == null)
+        {
+            Debug.LogWarning("[ResoniteBipedAvatarDescriptor] RecomputeHipsReference: Biped is null.");
+            return false;
+        }
+
+        var rotation = useGlobalOrientation ? Quaternion.identity : transform.rotation;
+        PositionReferenceAtBone(HipsReference, HumanBodyBones.Hips, rotation);
+        return true;
+    }
+
+    public bool TryFixHipsRotation()
+    {
+        if (HipsReference == null || Biped == null)
+            return false;
+
+        var hipsBone = Biped.GetBoneTransform(HumanBodyBones.Hips);
+        if (hipsBone == null)
+            return false;
+
+        Transform tailChild = null;
+        for (int i = 0; i < hipsBone.childCount; i++)
+        {
+            if (hipsBone.GetChild(i).name.IndexOf("tail", System.StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                tailChild = hipsBone.GetChild(i);
+                break;
+            }
+        }
+
+        if (tailChild == null)
+            return false;
+
+        var awayFromTail = (hipsBone.position - tailChild.position).normalized;
+        var flattenedForward = Vector3.ProjectOnPlane(awayFromTail, HipsReference.up).normalized;
+
+        if (flattenedForward.sqrMagnitude < 0.001f)
+            return false;
+
+        HipsReference.rotation = Quaternion.LookRotation(flattenedForward, HipsReference.up);
+        return true;
+    }
+
+    public bool TryFixHipsRotationFromBelly()
+    {
+        if (HipsReference == null || Biped == null)
+            return false;
+
+        var hipsBone = Biped.GetBoneTransform(HumanBodyBones.Hips);
+        if (hipsBone == null)
+            return false;
+
+        Transform bellyChild = null;
+        for (int i = 0; i < hipsBone.childCount; i++)
+        {
+            if (hipsBone.GetChild(i).name.IndexOf("belly", System.StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                bellyChild = hipsBone.GetChild(i);
+                break;
+            }
+        }
+
+        if (bellyChild == null)
+            return false;
+
+        var towardsBelly = (bellyChild.position - hipsBone.position).normalized;
+        var flattenedForward = Vector3.ProjectOnPlane(towardsBelly, HipsReference.up).normalized;
+
+        if (flattenedForward.sqrMagnitude < 0.001f)
+            return false;
+
+        HipsReference.rotation = Quaternion.LookRotation(flattenedForward, HipsReference.up);
+        return true;
+    }
+
+    public bool MirrorRotation(Transform source, Transform target, int axisFlags)
+    {
+        if (source == null)
+        {
+            Debug.LogWarning("[ResoniteBipedAvatarDescriptor] MirrorRotation: source transform is null.");
+            return false;
+        }
+
+        if (target == null)
+        {
+            Debug.LogWarning("[ResoniteBipedAvatarDescriptor] MirrorRotation: target transform is null.");
+            return false;
+        }
+
+        var rootRotation = transform.rotation;
+        var inverseRootRotation = Quaternion.Inverse(rootRotation);
+
+        var localForward = inverseRootRotation * source.forward;
+        var localUp = inverseRootRotation * source.up;
+
+        if ((axisFlags & 1) != 0) { localForward.x = -localForward.x; localUp.x = -localUp.x; }
+        if ((axisFlags & 2) != 0) { localForward.y = -localForward.y; localUp.y = -localUp.y; }
+        if ((axisFlags & 4) != 0) { localForward.z = -localForward.z; localUp.z = -localUp.z; }
+
+        var mirroredForward = rootRotation * localForward;
+        var mirroredUp = rootRotation * localUp;
+
+        if (mirroredForward.sqrMagnitude < 0.001f)
+            return false;
+
+        target.rotation = Quaternion.LookRotation(mirroredForward, mirroredUp);
+        return true;
+    }
+
+    public bool TryFixFootRotation(bool isRightFoot)
+    {
+        var footReference = isRightFoot ? RightFootReference : LeftFootReference;
+        if (footReference == null || Biped == null)
+            return false;
+
+        var footBone = Biped.GetBoneTransform(isRightFoot ? HumanBodyBones.RightFoot : HumanBodyBones.LeftFoot);
+        if (footBone == null)
+            return false;
+
+        var toesBone = Biped.GetBoneTransform(isRightFoot ? HumanBodyBones.RightToes : HumanBodyBones.LeftToes);
+
+        if (toesBone == null)
+        {
+            for (int i = 0; i < footBone.childCount; i++)
+            {
+                if (footBone.GetChild(i).name.IndexOf("toe", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    toesBone = footBone.GetChild(i);
+                    break;
+                }
+            }
+        }
+
+        if (toesBone == null)
+            return false;
+
+        var footToToes = (toesBone.position - footBone.position).normalized;
+        var flattenedForward = Vector3.ProjectOnPlane(footToToes, footReference.up).normalized;
+
+        if (flattenedForward.sqrMagnitude < 0.001f)
+            return false;
+
+        footReference.rotation = Quaternion.LookRotation(flattenedForward, footReference.up);
+        return true;
     }
 
     void SetupAnchors(Transform root)
@@ -246,6 +428,12 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
             centerPoint += forwardDir * 0.05f;
         }
 
+        if (ViewpointReference == null)
+        {
+            Debug.LogWarning("[ResoniteBipedAvatarDescriptor] TryPositionReferences: ViewpointReference is null.");
+            return;
+        }
+
         ViewpointReference.position = centerPoint;
         ViewpointReference.rotation = Quaternion.LookRotation(forwardDir, upDir);
 
@@ -277,11 +465,25 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
 
         var rightArmForward = (rightHand.position - rightArmBase.position).normalized;
 
-        LeftHandReference.position = leftHand.position;
-        LeftHandReference.rotation = Quaternion.LookRotation(leftArmForward, Vector3.up);
+        if (LeftHandReference != null)
+        {
+            LeftHandReference.position = leftHand.position;
+            LeftHandReference.rotation = Quaternion.LookRotation(leftArmForward, Vector3.up);
+        }
+        else
+        {
+            Debug.LogWarning("[ResoniteBipedAvatarDescriptor] TryPositionReferences: LeftHandReference is null.");
+        }
 
-        RightHandReference.position = rightHand.position;
-        RightHandReference.rotation = Quaternion.LookRotation(rightArmForward, Vector3.up);
+        if (RightHandReference != null)
+        {
+            RightHandReference.position = rightHand.position;
+            RightHandReference.rotation = Quaternion.LookRotation(rightArmForward, Vector3.up);
+        }
+        else
+        {
+            Debug.LogWarning("[ResoniteBipedAvatarDescriptor] TryPositionReferences: RightHandReference is null.");
+        }
     }
 
     public void RepositionOptionalReference(Transform generatedSlot, Transform targetBone)
@@ -418,9 +620,13 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
         var leftHandSlot = LeftHandReference.GetSlot();
         var rightHandSlot = RightHandReference.GetSlot();
 
-        var leftFootSlot = LeftFootReference.GetSlot();
-        var rightFootSlot = RightFootReference.GetSlot();
-        var hipsSlot = HipsReference.GetSlot();
+        var leftFootSlot = LeftFootReference != null ? LeftFootReference.GetSlot() : null;
+        var rightFootSlot = RightFootReference != null ? RightFootReference.GetSlot() : null;
+        var hipsSlot = HipsReference != null ? HipsReference.GetSlot() : null;
+
+        if (leftFootSlot == null) Debug.LogWarning("[ResoniteBipedAvatarDescriptor] PostProcessConversion: LeftFootReference is null, skipping left foot slot.");
+        if (rightFootSlot == null) Debug.LogWarning("[ResoniteBipedAvatarDescriptor] PostProcessConversion: RightFootReference is null, skipping right foot slot.");
+        if (hipsSlot == null) Debug.LogWarning("[ResoniteBipedAvatarDescriptor] PostProcessConversion: HipsReference is null, skipping hips slot.");
 
         Task.Run(async () =>
         {

--- a/Assets/ResoniteSDK/Processors/Avatar/ResoniteBipedAvatarDescriptor.cs
+++ b/Assets/ResoniteSDK/Processors/Avatar/ResoniteBipedAvatarDescriptor.cs
@@ -35,39 +35,10 @@ public class ResoniteBipedAvatarDescriptor : MonoBehaviour, IConversionPostProce
     [ExecuteInEditMode]
     void Awake()
     {
-        // If biped has already been assigned, do not run the auto setup
         if (Biped != null)
             return;
 
-        // Try to initialize the biped on attach
-        Biped = GetComponent<Animator>();
-
-        // Initialize references
-        if (ViewpointReference == null && LeftHandReference == null && RightHandReference == null)
-        {
-            var references = new GameObject("References");
-            references.transform.SetParent(transform, false);
-            references.transform.localPosition = Vector3.zero;
-            references.transform.localRotation = Quaternion.identity;
-
-            var viewpoint = new GameObject("Viewpoint");
-            viewpoint.transform.SetParent(references.transform, false);
-            ViewpointReference = viewpoint.transform;
-
-            var leftHand = new GameObject("Left Hand");
-            leftHand.transform.SetParent(references.transform, false);
-            LeftHandReference = leftHand.transform;
-
-            SetupAnchors(LeftHandReference);
-
-            var rightHand = new GameObject("Right Hand");
-            rightHand.transform.SetParent(references.transform, false);
-            RightHandReference = rightHand.transform;
-
-            SetupAnchors(RightHandReference);
-
-            TryPositionReferences();
-        }
+        EnsureReferencesExist();
     }
 
     public Transform EnsureReferencesExist()


### PR DESCRIPTION
Refactors parts of my Avatar Setup Wizard, properly implements optional bone setup and adds a buch of vector tools to assist users with Avatar Setup.

Also adds some sectioning comments into my code so i remember to add features related to each other in the same section blocks

Also thought it may be useful if people can programmatically parse my changes so below is a machine readable changelog

:cl:
add: Rotation Tools section with Fix (Toes), Fix (Tail), Fix (Belly) for per-reference Y-axis rotation correction
add: Generic MirrorRotation method with bit flag axis selection (1=X, 2=Y, 4=Z) operating in avatar root local space
add: Mirror L to R and Mirror R to L buttons for foot references
add: Compute Left/Right/Hips buttons to reset individual references to initial bone position and rotation
add: Use Global Forward/Up toggle for initial reference generation with root deviation warning
add: EnsureReferencesExist recovery method for regenerating deleted References hierarchy without full revert
add: TryFixFootRotation dual check falling back to child bones containing "toe" if humanoid toes missing
qol: Reorganized wizard UI with Setup/Revert buttons at top, collapsible Tools and Edit Visuals foldouts below
qol: Wizard detects existing ResoniteBipedAvatarDescriptor on avatar root change and populates setup flags
qol: Optional reference overrides cleared on avatar root swap to prevent stale positioning
fix: Optional reference slots use avatar root rotation instead of unreliable bone axis rotation
fix: Added null guards with Debug.LogWarning on all public descriptor methods
fix: PostProcessConversion null-safe for optional foot and hips references
fix: Dirty marking on rotation fix buttons for immediate gizmo updates
doc: Added section markers into ResoniteAvatarSetupWizard
fix: try position Tool anchors records child movement now for undo.
clean: Downgrade Logs that act as pure reminders and are not actually an issue from Warn to Log
clean: remove duplicate [ExecuteInEditMode] flag
/:cl: