### PR TITLE
[Build] Copy the outputs Resonite.UnitySDK.Bindings to the SDK plugins automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,12 @@ Resonite.UnitySDK.sln
 # Visual Studio cache directory
 .vs/
 
+# Visual Studio: Code workspace directory
+.vscode/
+
+# Zed sworkspace directory
+.zed/
+
 # Gradle cache directory
 .gradle/
 

--- a/BindingsGenerator/Directory.Build.props
+++ b/BindingsGenerator/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<HomeFolder>$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/</HomeFolder>
+	<IsWindows>$([MSBuild]::IsOSPlatform('Windows'))</IsWindows>
+	<IsLinux>$([MSBuild]::IsOSPlatform('Linux'))</IsLinux>
+	<IsOSX>$([MSBuild]::IsOSPlatform('OSX'))</IsOSX>
+
+
+	<UnityEditorPath>C:/Program Files/Unity/</UnityEditorPath>
+	<UnityEditorPath Condition="'$(IsLinux)' == 'true'">$(HomeFolder)/Unity/</UnityEditorPath>
+</Project>

--- a/BindingsGenerator/Directory.Build.props
+++ b/BindingsGenerator/Directory.Build.props
@@ -1,10 +1,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<HomeFolder>$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/</HomeFolder>
-	<IsWindows>$([MSBuild]::IsOSPlatform('Windows'))</IsWindows>
-	<IsLinux>$([MSBuild]::IsOSPlatform('Linux'))</IsLinux>
-	<IsOSX>$([MSBuild]::IsOSPlatform('OSX'))</IsOSX>
+	<PropertyGroup>
+		<HomeFolder>$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/</HomeFolder>
+		<IsWindows>$([MSBuild]::IsOSPlatform('Windows'))</IsWindows>
+		<IsLinux>$([MSBuild]::IsOSPlatform('Linux'))</IsLinux>
+		<IsOSX>$([MSBuild]::IsOSPlatform('OSX'))</IsOSX>
 
 
-	<UnityEditorPath>C:/Program Files/Unity/</UnityEditorPath>
-	<UnityEditorPath Condition="'$(IsLinux)' == 'true'">$(HomeFolder)/Unity/</UnityEditorPath>
+		<UnityEditorPath>C:/Program Files/Unity/</UnityEditorPath>
+		<UnityEditorPath Condition="'$(IsLinux)' == 'true'">$(HomeFolder)/Unity/</UnityEditorPath>
+	</PropertyGroup>
 </Project>

--- a/BindingsGenerator/Directory.Build.targets
+++ b/BindingsGenerator/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(ProjectDir)BuildOutput.targets" Condition="Exists('$(ProjectDir)BuildOutput.targets')"/>
+</Project>

--- a/BindingsGenerator/Resonite.UnitySDK.BindingGenerator/Resonite.UnitySDK.BindingGenerator.csproj
+++ b/BindingsGenerator/Resonite.UnitySDK.BindingGenerator/Resonite.UnitySDK.BindingGenerator.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\Program Files\Unity\Hub\Editor\2022.3.62f3\Editor\Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(UnityEditorPath)Hub/Editor/2022.3.62f3/Editor/Data/Managed/UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/BindingsGenerator/Resonite.UnitySDK.Bindings/BuildOutput.targets
+++ b/BindingsGenerator/Resonite.UnitySDK.Bindings/BuildOutput.targets
@@ -1,0 +1,21 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<PropertyGroup>
+		<BindingsOutputPath>$(OutDir)../../../../../Assets/ResoniteSDK/Plugins/</BindingsOutputPath>
+	</PropertyGroup>
+
+	<Target Name="CopyToBuilds" AfterTargets="PostBuildEvent">
+		<ItemGroup>
+			<CopyToOutput Include="$(OutDir)**/*.*" >
+				<Destination>$(BindingsOutputPath)</Destination>
+			</CopyToOutput>
+		</ItemGroup>
+
+		<Copy
+			SourceFiles="%(CopyToOutput.Identity)"
+			DestinationFiles="%(CopyToOutput.Destination)%(RecursiveDir)%(Filename)%(Extension)"
+			SkipUnchangedFiles="false"
+		/>
+
+	</Target>
+</Project>

--- a/BindingsGenerator/Resonite.UnitySDK.Bindings/Resonite.UnitySDK.Bindings.csproj
+++ b/BindingsGenerator/Resonite.UnitySDK.Bindings/Resonite.UnitySDK.Bindings.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Resonite.UnitySDK.Core\Resonite.UnitySDK.Core.csproj" />
+    <ProjectReference Include="../Resonite.UnitySDK.Core/Resonite.UnitySDK.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Conversion\FieldAndArrayConverter.tt">
+    <None Update="Conversion/FieldAndArrayConverter.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>FieldAndArrayConverter.cs</LastGenOutput>
     </None>
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="Conversion\FieldAndArrayConverter.cs">
+    <Compile Update="Conversion/FieldAndArrayConverter.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>FieldAndArrayConverter.tt</DependentUpon>
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Extensions\StaticAssets\" />
+    <Folder Include="Extensions/StaticAssets/" />
   </ItemGroup>
 
 </Project>

--- a/BindingsGenerator/Resonite.UnitySDK.Bindings/Resonite.UnitySDK.Bindings.csproj
+++ b/BindingsGenerator/Resonite.UnitySDK.Bindings/Resonite.UnitySDK.Bindings.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\Program Files\Unity\Hub\Editor\2022.3.62f3\Editor\Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(UnityEditorPath)Hub/Editor/2022.3.62f3/Editor/Data/Managed/UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/BindingsGenerator/Resonite.UnitySDK.Core/Resonite.UnitySDK.Core.csproj
+++ b/BindingsGenerator/Resonite.UnitySDK.Core/Resonite.UnitySDK.Core.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\Program Files\Unity\Hub\Editor\2022.3.62f3\Editor\Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(UnityEditorPath)Hub/Editor/2022.3.62f3/Editor/Data/Managed/UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
# Description

This PR should satisfy #55 by copying the build output of `Resonite.UnitySDK.Bindings` to `Assets/ResoniteSDK/Plugins/` automatically.

Included is some basic OS detection and a Linux conditional so that the binding generator projects can build on Linux out-of-the-box.

Also included is a tiny fixup to use forward slashes. This will have no negative affect on Windows as the build system interprets these correctly no matter the platform.

I've tested the build of the binding generator and it appears to copy to the requested output directory sucessfully.