### PR TITLE
Do not raise exception when converting procedural assets (eg gradient textures)

### DIFF
--- a/Assets/ResoniteSDK/AssetConverters/AssetConverter.cs
+++ b/Assets/ResoniteSDK/AssetConverters/AssetConverter.cs
@@ -104,6 +104,13 @@ public abstract class AssetConverter<TWrapper, TProvider, TUnity, TResonite> : A
         if (assetPath == null)
             throw new Exception($"Could not get asset path for asset: {Source}");
 
+        if (string.IsNullOrWhiteSpace(assetPath))
+        {
+            // Most likely a procedural asset
+            Debug.Log($"Re-converting procedural asset {Source}");
+            return (ulong) DateTime.UtcNow.Ticks;
+        }
+
         var importer = AssetImporter.GetAtPath(assetPath);
 
         if (importer == null)


### PR DESCRIPTION
Some Unity components can make use of internal procedural assets, such as gradient textures. For example, this is the case for the Poiyomi Toon’s shadow ramp texture. (Cf. #83 )

Such assets have a blank (but not null) name, and Unity will be unable to obtain its asset importer, because it is technically not backed by anything tangible on disk.

This workaround allows us to convert procedural assets, by assuming by default that they have changed since the last conversion.