### PR TITLE
[Texture2DConverter] Fix textures being vertically flipped when transmitting raw texture data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,10 @@ InitTestScene*.unity*
 # Auto-generated scenes by play mode tests
 /[Aa]ssets/[Ii]nit[Tt]est[Ss]cene*.unity*
 
+# Auto-generated on Linux systems, apparently
+/[Aa]ssets/csc.rsp
+/[Aa]ssets/csc.rsp.meta
+
 # Custom material packages
 ## Poiyomi
 /[Pp]ackages/com.poiyomi.toon

--- a/Assets/ResoniteSDK/AssetConverters/Texture2DConverter.cs
+++ b/Assets/ResoniteSDK/AssetConverters/Texture2DConverter.cs
@@ -1,4 +1,4 @@
-﻿using Elements.Assets;
+using Elements.Assets;
 using FrooxEngine;
 using ResoniteLink;
 using System;
@@ -105,11 +105,11 @@ public class Texture2DConverter : AssetConverter<StaticTexture2DWrapper, StaticT
         {
             assetPath = Path.GetFullPath(assetPath);
 
-            if(File.Exists(assetPath) && AssetConversionHelper.IsTextureFileSupportedByResonite(assetPath))
+            if (File.Exists(assetPath) && AssetConversionHelper.IsTextureFileSupportedByResonite(assetPath))
                 return new ImportTexture2DFile() { FilePath = assetPath };
         }
 
-        if(!texture.isReadable)
+        if (!texture.isReadable)
         {
             var readableTexture = new UnityEngine.Texture2D(texture.width, texture.height,
                 texture.format.IsHDR() ? TextureFormat.RGBAHalf : TextureFormat.RGBA32, false);
@@ -132,11 +132,19 @@ public class Texture2DConverter : AssetConverter<StaticTexture2DWrapper, StaticT
             var pixels = texture.GetPixels(0);
 
             for (int y = 0; y < import.Height; y++)
-                for(int x = 0; x < import.Width; x++)
+            {
+                int ySource = y;
+                if (!SystemInfo.graphicsUVStartsAtTop)
                 {
-                    var c = pixels[x + y * import.Width];
+                    // On OpenGL systems (e.g. Linux) GetPixels returns them from bottom to top
+                    ySource = import.Height - 1 - y;
+                }
+                for (int x = 0; x < import.Width; x++)
+                {
+                    var c = pixels[x + ySource * import.Width];
                     data[x, y] = c.ToResoniteLink();
                 }
+            }
 
             return import;
         }
@@ -152,11 +160,19 @@ public class Texture2DConverter : AssetConverter<StaticTexture2DWrapper, StaticT
             var pixels = texture.GetPixels32(0);
 
             for (int y = 0; y < import.Height; y++)
+            {
+                int ySource = y;
+                if (!SystemInfo.graphicsUVStartsAtTop)
+                {
+                    // On OpenGL systems (e.g. Linux) GetPixels returns them from bottom to top
+                    ySource = import.Height - 1 - y;
+                }
                 for (int x = 0; x < import.Width; x++)
                 {
-                    var c = pixels[x + y * import.Width];
+                    var c = pixels[x + ySource * import.Width];
                     data[x, y] = c.ToResoniteLink();
                 }
+            }
 
             return import;
         }

--- a/Assets/ResoniteSDK/AssetConverters/Texture2DConverter.cs
+++ b/Assets/ResoniteSDK/AssetConverters/Texture2DConverter.cs
@@ -133,12 +133,8 @@ public class Texture2DConverter : AssetConverter<StaticTexture2DWrapper, StaticT
 
             for (int y = 0; y < import.Height; y++)
             {
-                int ySource = y;
-                if (!SystemInfo.graphicsUVStartsAtTop)
-                {
-                    // On OpenGL systems (e.g. Linux) GetPixels returns them from bottom to top
-                    ySource = import.Height - 1 - y;
-                }
+                // GetPixels returns them from bottom to top, and ResoniteLink expects them from top to bottom
+                int ySource = import.Height - 1 - y;
                 for (int x = 0; x < import.Width; x++)
                 {
                     var c = pixels[x + ySource * import.Width];
@@ -161,12 +157,8 @@ public class Texture2DConverter : AssetConverter<StaticTexture2DWrapper, StaticT
 
             for (int y = 0; y < import.Height; y++)
             {
-                int ySource = y;
-                if (!SystemInfo.graphicsUVStartsAtTop)
-                {
-                    // On OpenGL systems (e.g. Linux) GetPixels returns them from bottom to top
-                    ySource = import.Height - 1 - y;
-                }
+                // GetPixels returns them from bottom to top, and ResoniteLink expects them from top to bottom
+                int ySource = import.Height - 1 - y;
                 for (int x = 0; x < import.Width; x++)
                 {
                     var c = pixels[x + ySource * import.Width];


### PR DESCRIPTION
This did not happen for textures backed by an asset, because these are imported by Resonite from the file path directly. This only concerns computed textures.
This only happened on Linux, because Unity uses OpenGL on these systems, and OpenGL vertically flips its UV compared to what DirectX does (bottom to top VS top to bottom).