### PR TITLE
Added heuristic matching to PBS & Unlit material converters

### DIFF
--- a/Assets/ResoniteSDK/MaterialConverters/PBS/StandardBaseConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/PBS/StandardBaseConverter.cs
@@ -1,4 +1,5 @@
 using FrooxEngine;
+using System.Collections.Generic;
 using UnityEngine;
 
 public abstract class StandardBaseConverter<TWrapper, TMaterial> : ResoniteMaterialConverter
@@ -6,6 +7,23 @@ public abstract class StandardBaseConverter<TWrapper, TMaterial> : ResoniteMater
     where TMaterial : FrooxEngine.PBS_Material, new()
 {
     public TWrapper PBS;
+
+    protected static readonly IEnumerable<string> BaseSupportedProperties = new List<string>()
+    {
+        "_Cutoff",
+        "_Color",
+
+        "_BumpMap",
+        "_BumpScale",
+
+        "_Parallax",
+        "_ParallaxMap",
+
+        "_OcclusionMap",
+
+        "_EmissionColor",
+        "_EmissionMap",
+    };
 
     public override IAssetProvider<FrooxEngine.Material> UpdateConversion(UnityEngine.Material material, IConversionContext context)
     {

--- a/Assets/ResoniteSDK/MaterialConverters/PBS/StandardConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/PBS/StandardConverter.cs
@@ -1,8 +1,17 @@
 using FrooxEngine;
+using System.Collections.Generic;
+using System.Linq;
 
-[MaterialConverter(false, "Standard")]
+[MaterialConverter(true, "Standard")]
 public class StandardConverter : StandardBaseConverter<PBS_MetallicWrapper, PBS_Metallic>
 {
+    protected static readonly IEnumerable<string> SupportedProperties = new List<string>()
+    {
+        "_Glossiness",
+        "_Metallic",
+        "_MetallicGlossMap",
+    };
+
     public override IAssetProvider<FrooxEngine.Material> UpdateConversion(UnityEngine.Material material, IConversionContext context)
     {
         var provider = base.UpdateConversion(material, context);
@@ -15,5 +24,14 @@ public class StandardConverter : StandardBaseConverter<PBS_MetallicWrapper, PBS_
         data.MetallicMap = context.GetITexture2D(material.GetTexture("_MetallicGlossMap"));
 
         return provider;
+    }
+
+    public static float? EvaluateHeuristicConversion(UnityEngine.Material material)
+    {
+        if (material.shader == null)
+            return null;
+
+        return PropertyBasedCompatibilityEvaluator.ComputeCompatibility(material,
+            SupportedProperties.Concat(BaseSupportedProperties));
     }
 }

--- a/Assets/ResoniteSDK/MaterialConverters/PBS/StandardSpecularConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/PBS/StandardSpecularConverter.cs
@@ -1,9 +1,18 @@
 using FrooxEngine;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 [MaterialConverter(false, "Standard (Specular setup)")]
 public class StandardSpecularConverter : StandardBaseConverter<PBS_SpecularWrapper, PBS_Specular>
 {
+    protected static readonly IEnumerable<string> SupportedProperties = new List<string>()
+    {
+        "_SpecColor",
+        "_Glossiness",
+        "_SpecGlossMap",
+    };
+
     public override IAssetProvider<FrooxEngine.Material> UpdateConversion(UnityEngine.Material material, IConversionContext context)
     {
         var provider = base.UpdateConversion(material, context);
@@ -19,5 +28,14 @@ public class StandardSpecularConverter : StandardBaseConverter<PBS_SpecularWrapp
         data.SpecularMap = context.GetITexture2D(material.GetTexture("_SpecGlossMap"));
 
         return provider;
+    }
+
+    public static float? EvaluateHeuristicConversion(UnityEngine.Material material)
+    {
+        if (material.shader == null)
+            return null;
+
+        return PropertyBasedCompatibilityEvaluator.ComputeCompatibility(material,
+            SupportedProperties.Concat(BaseSupportedProperties));
     }
 }

--- a/Assets/ResoniteSDK/MaterialConverters/PropertyBasedCompatibilityEvaluator.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/PropertyBasedCompatibilityEvaluator.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+public static class PropertyBasedCompatibilityEvaluator
+{
+    /// <summary>
+    /// Computes a simple heuristic score for matching a material based on how many properties match (and don't match).
+    /// Each matching property gives it a point. Each mismatching property removes a point.
+    /// </summary>
+    /// <param name="material">The material whose compatibility is being computed</param>
+    /// <param name="supportedProperties">List of supported properties by the material</param>
+    /// <returns></returns>
+    public static float ComputeCompatibility(UnityEngine.Material material, IEnumerable<string> supportedProperties)
+    {
+        // No shader means we can't match this
+        if (material.shader == null)
+            return float.NegativeInfinity;
+
+        // Collect all supported properties and normalize them
+        var normalizedProperties = new HashSet<string>();
+
+        foreach (var property in supportedProperties)
+            normalizedProperties.Add(NormalizePropertyName(property));
+
+        float score = 0f;
+
+        var propertyCount = material.shader.GetPropertyCount();
+
+        for(int i = 0; i < propertyCount; i++)
+        {
+            var name = material.shader.GetPropertyName(i);
+            name = NormalizePropertyName(name);
+
+            if (normalizedProperties.Remove(name))
+                score += 1f; // A match! Add a point.
+            else
+                score -= 1f; // Not supported, remove point.
+        }
+
+        // For any property that the shader supports, but that's not needed, lose half a point
+        // This is for cases like PBS matching simple Unlit material, where the only needed thing is main texture
+        // and color tint, the extra properties on PBS will disadvantage it over simpler materials like Unlit
+        // Assuming there's no other filtering going on
+        score -= normalizedProperties.Count * 0.5f;
+
+        return score;
+    }
+
+    /// <summary>
+    /// Normalizes the property name so small differences like underscores and case don't matter.
+    /// </summary>
+    /// <param name="propertyName">Property name to normalize</param>
+    /// <returns>Normalized property name</returns>
+    public static string NormalizePropertyName(string propertyName) => propertyName.Replace("_", "").ToLowerInvariant();
+}

--- a/Assets/ResoniteSDK/MaterialConverters/PropertyBasedCompatibilityEvaluator.cs.meta
+++ b/Assets/ResoniteSDK/MaterialConverters/PropertyBasedCompatibilityEvaluator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e1f95d38923c9eb46ab0941f83c61bca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ResoniteSDK/MaterialConverters/Unlit/UnlitConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Unlit/UnlitConverter.cs
@@ -1,7 +1,8 @@
 using FrooxEngine;
+using System.Collections.Generic;
 using UnityEngine;
 
-[MaterialConverter(false, 
+[MaterialConverter(true, 
     "Unlit/Transparent", 
     "Unlit/Transparent Cutout",
     "Unlit/Texture",
@@ -11,6 +12,13 @@ using UnityEngine;
 public class UnlitTransparentConverter : ResoniteMaterialConverter
 {
     public FrooxEngine.UnlitMaterialWrapper Unlit;
+
+    protected static readonly IEnumerable<string> SupportedProperties = new List<string>()
+    {
+        "_Color",
+        "_Cutoff",
+        "_Cull",
+    };
 
     public override IAssetProvider<FrooxEngine.Material> UpdateConversion(UnityEngine.Material material, IConversionContext context)
     {
@@ -83,5 +91,13 @@ public class UnlitTransparentConverter : ResoniteMaterialConverter
         }
 
         return data;
+    }
+
+    public static float? EvaluateHeuristicConversion(UnityEngine.Material material)
+    {
+        if (material.shader == null)
+            return null;
+
+        return PropertyBasedCompatibilityEvaluator.ComputeCompatibility(material, SupportedProperties);
     }
 }


### PR DESCRIPTION
This ensures that PBS & Unlit materials will be often used as a fallback when a shader isn't directly supported, rather than just a null (missing) shader.

This should generally be better than the shader not converting at all - it will try to do best effort to convert to something matching, which provides better visual.

The heuristics are very simple - just match the properties of the shader against the supported shader. The more match, the higher score. The more mismatch, the lower the score.

Feel free to build upon these and expand the heuristics as needed! My goal is to provide initial base to make the SDK behave better in this area.

The heuristics are also meant as a fallback - they will often convert stuff "wrong" - meaning we should add conversions for specific shaders to be handled better.