### PR TITLE
Fix some non-readnable textures failing to convert due to format mismatch

### DIFF
--- a/Assets/ResoniteSDK/AssetConverters/Texture2DConverter.cs
+++ b/Assets/ResoniteSDK/AssetConverters/Texture2DConverter.cs
@@ -120,8 +120,7 @@ public class Texture2DConverter : AssetConverter<StaticTexture2DWrapper, StaticT
 
         if (!texture.isReadable)
         {
-            var readableTexture = new UnityEngine.Texture2D(texture.width, texture.height,
-                texture.format.IsHDR() ? TextureFormat.RGBAHalf : TextureFormat.RGBA32, false);
+            var readableTexture = new UnityEngine.Texture2D(texture.width, texture.height, texture.format, false);
 
             Graphics.CopyTexture(texture, 0, 0, readableTexture, 0, 0);
 


### PR DESCRIPTION
I've ran into issue where some textures don't convert, because the Graphics.Copy needs the format to match exactly. This fixes that.