### PR TITLE
Reflect Unity TextureImporter.maxTextureSize into Resonite StaticTexture2D.MaxSize

### DIFF
--- a/Assets/ResoniteSDK/AssetConverters/Texture2DConverter.cs
+++ b/Assets/ResoniteSDK/AssetConverters/Texture2DConverter.cs
@@ -16,6 +16,7 @@ public class Texture2DConverter : AssetConverter<StaticTexture2DWrapper, StaticT
     int? _anisoLevel;
     bool _uncompressed;
     bool _crunchCompressed;
+    int? _maxSize;
     bool _mipMaps;
     bool _readable;
 
@@ -57,6 +58,13 @@ public class Texture2DConverter : AssetConverter<StaticTexture2DWrapper, StaticT
 
         _readable = Source.isReadable;
 
+        var assetPath = AssetDatabase.GetAssetPath(Source);
+
+        if (!string.IsNullOrWhiteSpace(assetPath) && AssetImporter.GetAtPath(assetPath) is TextureImporter textureImporter)
+            _maxSize = textureImporter.maxTextureSize;
+        else
+            _maxSize = null;
+
         return ConvertTexture2D(Source, PostProcessor != null);
     }
 
@@ -96,6 +104,8 @@ public class Texture2DConverter : AssetConverter<StaticTexture2DWrapper, StaticT
         Provider.Data.CrunchCompressed = _crunchCompressed;
 
         Provider.Data.Readable = _readable;
+
+        Provider.Data.MaxSize = _maxSize;
 
         return Provider.CollectData(context);
     }


### PR DESCRIPTION
Avatars configured in Unity for other platforms, such as VRChat, may use Unity’s `TextureImporter.maxTextureSize` to adjust texture resolution.

In those cases, setting Resonite’s `StaticTexture2D.MaxSize` to the same value should produce equivalent behavior.
