### PR TITLE
lilToon material coneverter

### DIFF
--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon.meta
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 09d621bdd5516074d8cb3c5a8f436628
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonAssetCache.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonAssetCache.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class LilToonAssetCache
+{
+    public Texture2D ShadowRampTexture;
+}

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonAssetCache.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonAssetCache.cs
@@ -5,8 +5,71 @@ public class LilToonAssetCache
 
     public Texture2D MainTexture;
 
+    public Hash128? MainTextureBakeHash;
+
     public Texture2D EmissionMap;
+
+    public Hash128? EmissionMapBakeHash;
 
     public Texture2D ShadowRampTexture;
 
+    public Hash128? ShadowRampBakeHash;
+
+    internal struct BakeHash
+    {
+        private Hash128 value;
+
+        public Hash128 Value => value;
+
+        public void Add(bool item)
+        {
+            value.Append(item ? 1 : 0);
+        }
+
+        public void Add(float item)
+        {
+            value.Append(item);
+        }
+
+        public void Add(Vector2 item)
+        {
+            value.Append(item.x);
+            value.Append(item.y);
+        }
+
+        public void Add(Vector4 item)
+        {
+            value.Append(item.x);
+            value.Append(item.y);
+            value.Append(item.z);
+            value.Append(item.w);
+        }
+
+        public void Add(Color item)
+        {
+            value.Append(item.r);
+            value.Append(item.g);
+            value.Append(item.b);
+            value.Append(item.a);
+        }
+
+        public void Add(Texture item)
+        {
+            if (item == null)
+            {
+                value.Append(0);
+                return;
+            }
+
+            value.Append(item.GetInstanceID());
+            value.Append((int)item.updateCount);
+            value.Append((int)item.wrapMode);
+            value.Append((int)item.wrapModeU);
+            value.Append((int)item.wrapModeV);
+            value.Append((int)item.wrapModeW);
+            value.Append((int)item.filterMode);
+            value.Append(item.anisoLevel);
+            value.Append(item.mipMapBias);
+        }
+    }
 }

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonAssetCache.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonAssetCache.cs
@@ -2,5 +2,9 @@ using UnityEngine;
 
 public class LilToonAssetCache
 {
+
+    public Texture2D EmissionMap;
+
     public Texture2D ShadowRampTexture;
+
 }

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonAssetCache.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonAssetCache.cs
@@ -3,6 +3,8 @@ using UnityEngine;
 public class LilToonAssetCache
 {
 
+    public Texture2D MainTexture;
+
     public Texture2D EmissionMap;
 
     public Texture2D ShadowRampTexture;

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonAssetCache.cs.meta
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonAssetCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a0c23c6b2be43b4aa1d9934dbda15a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonConverter.cs
@@ -1,0 +1,30 @@
+using FrooxEngine;
+using UnityEngine;
+
+// lilToon shaders are freely available under the MIT license.
+// Documentation and download links are available at https://lilxyzw.github.io/lilToon/
+[MaterialConverter(true, "lilToon")]
+public class LilToonConverter : ResoniteMaterialConverter
+{
+    private XiexeToonMaterialWrapper XiexeComponent;
+    private readonly LilToonAssetCache AssetCache = new();
+
+    public static float? EvaluateHeuristicConversion(UnityEngine.Material material)
+    {
+        if (!material.shader.name.Contains("lilToon"))
+        {
+            return null;
+        }
+        return 0;
+    }
+
+    public override IAssetProvider<FrooxEngine.Material> UpdateConversion(UnityEngine.Material material, IConversionContext context)
+    {
+        if (XiexeComponent == null)
+        {
+            XiexeComponent = gameObject.AddComponent<XiexeToonMaterialWrapper>();
+        }
+
+        return new LilToonXiexeConverter(XiexeComponent.Data, material, context, AssetCache).UpdateConversion();
+    }
+}

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonConverter.cs.meta
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c918ad5033459af44879830b673460c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonFakeShadowConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonFakeShadowConverter.cs
@@ -1,0 +1,30 @@
+using FrooxEngine;
+using UnityEngine;
+
+// lilToon FakeShadow is a projected/offset unlit helper rather than a surface
+// material. Do not approximate it as XiexeToon, because that produces a
+// visibly different colored overlay.
+[MaterialConverter(false, "_lil/[Optional] lilToonFakeShadow")]
+public class LilToonFakeShadowConverter : ResoniteMaterialConverter
+{
+    private UnlitMaterialWrapper Unlit;
+
+    public override IAssetProvider<FrooxEngine.Material> UpdateConversion(
+        UnityEngine.Material material,
+        IConversionContext context)
+    {
+        if (Unlit == null)
+        {
+            Unlit = gameObject.AddComponent<UnlitMaterialWrapper>();
+        }
+
+        var data = Unlit.Data;
+        data.TintColor = UnityEngine.Color.clear.ToColorX_sRGB();
+        data.BlendMode = BlendMode.Cutout;
+        data.AlphaCutoff = 1;
+        data.Sidedness = Sidedness.Front;
+        data.Texture = null;
+
+        return data;
+    }
+}

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonFakeShadowConverter.cs.meta
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonFakeShadowConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4292b47d3b95604e8b47a3bded4f3ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -88,8 +88,9 @@ public class LilToonXiexeConverter
 
         var shouldBakeAlpha = Material.GetFloat("_AlphaMaskMode") != 0
             && Material.GetTexture("_AlphaMask") != null;
+        var shouldBakeMainColor = shouldBakeMain || shouldBakeMain2nd || shouldBakeMain3rd;
 
-        if (!shouldBakeMain && !shouldBakeMain2nd && !shouldBakeMain3rd && !shouldBakeAlpha)
+        if (!shouldBakeMainColor && !shouldBakeAlpha)
         {
             return defaultData;
         }
@@ -98,7 +99,7 @@ public class LilToonXiexeConverter
         if (AssetCache.MainTexture != null && AssetCache.MainTextureBakeHash == bakeHash)
         {
             return new MainTextureData(AssetCache.MainTexture,
-                Color.white,
+                shouldBakeMainColor ? Color.white : defaultData.Color,
                 Vector2.one,
                 Vector2.zero);
         }
@@ -128,7 +129,7 @@ public class LilToonXiexeConverter
             }
 
             var sourceTexture2D = Material.mainTexture ?? UnityEngine.Texture2D.whiteTexture;
-            if (shouldBakeMain || shouldBakeMain2nd || shouldBakeMain3rd)
+            if (shouldBakeMainColor)
             {
                 bakedTexture = BakeMaterialToTexture(sourceTexture2D, bakerMaterial);
                 bakedTexture.name = $"{Material.name}_MainTex_Baked";
@@ -189,7 +190,7 @@ public class LilToonXiexeConverter
         AssetCache.MainTexture = bakedTexture;
         AssetCache.MainTextureBakeHash = bakeHash;
         return new MainTextureData(bakedTexture,
-            Color.white,
+            shouldBakeMainColor ? Color.white : defaultData.Color,
             Vector2.one,
             Vector2.zero);
     }

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -41,6 +41,7 @@ public class LilToonXiexeConverter
         UpdateRenderSettings();
         Xiexe.ShadowRim = Color.white.ToColorX_sRGB();
         UpdateEmission(mainTexture.Texture, mainTexture.Scale, mainTexture.Offset);
+        UpdateMatcap();
         UpdateOcclusion();
         UpdateOutline();
         UpdateShadowRamp();
@@ -402,6 +403,40 @@ public class LilToonXiexeConverter
         Xiexe.EmissionMapScale = Vector2.one;
         Xiexe.EmissionMapOffset = Vector2.zero;
         Xiexe.EmissionUV = 0;
+    }
+
+    private void UpdateMatcap()
+    {
+        // Xiexe only supports additive MatCap and has no equivalent to lilToon's
+        // _MatCapBlendMask. Applying unsupported modes or an unmasked MatCap changes
+        // the look, so only convert additive, unmasked MatCap.
+        if (Material.GetFloat("_UseMatCap") == 0 ||
+            Material.GetFloat("_MatCapBlendMode") != 1 ||
+            Material.GetTexture("_MatCapBlendMask") != null)
+        {
+            Xiexe.Matcap = null;
+            return;
+        }
+
+        Xiexe.Matcap = Context.GetITexture2D(Material.GetTexture("_MatCapTex"), OpacifyProcessor);
+        var matcapColor = Material.GetColor("_MatCapColor");
+        var alpha = matcapColor.a;
+        matcapColor *= Material.GetFloat("_MatCapBlend") * alpha;
+        matcapColor.a = alpha;
+        Xiexe.MatcapTint = matcapColor.ToColorX_sRGB();
+    }
+
+    private static readonly AssetMessagePostProcessor OpacifyProcessor = TexturePostProcessing.ProcessPixels(Opacify);
+
+    private static ResoniteLink.color Opacify(ResoniteLink.color c)
+    {
+        return new ResoniteLink.color()
+        {
+            r = c.r * c.a,
+            g = c.g * c.a,
+            b = c.b * c.a,
+            a = c.a,
+        };
     }
 
     private void UpdateOcclusion()

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -5,6 +5,22 @@ using UnityEditor;
 
 public class LilToonXiexeConverter
 {
+    private struct MainTextureData
+    {
+        public readonly Texture Texture;
+        public readonly Color Color;
+        public readonly Vector2 Scale;
+        public readonly Vector2 Offset;
+
+        public MainTextureData(Texture texture, Color color, Vector2 scale, Vector2 offset)
+        {
+            Texture = texture;
+            Color = color;
+            Scale = scale;
+            Offset = offset;
+        }
+    }
+
     private readonly XiexeToonMaterial Xiexe;
     private readonly UnityEngine.Material Material;
     private readonly IConversionContext Context;
@@ -20,23 +36,144 @@ public class LilToonXiexeConverter
 
     public IAssetProvider<FrooxEngine.Material> UpdateConversion()
     {
-        var mainTexture = Material.mainTexture;
-        var mainTextureScale = Material.mainTextureScale;
-        var mainTextureOffset = Material.mainTextureOffset;
-        Xiexe.MainTexture = Context.GetITexture2D(mainTexture);
-        Xiexe.MainTextureScale = mainTextureScale;
-        Xiexe.MainTextureOffset = mainTextureOffset;
-        Xiexe.Color = Material.GetColor("_Color").ToColorX_sRGB();
+        var mainTexture = GetMainTexture();
+        UpdateMainTexture(mainTexture);
         Xiexe.Saturation = 1;
         Xiexe.ShadowRim = Color.white.ToColorX_sRGB();
         Xiexe.ColorMask = (ColorMask)Material.GetFloat("_ColorMask");
         Xiexe.RenderQueue = Material.renderQueue;
-        UpdateEmission(mainTexture, mainTextureScale, mainTextureOffset);
+        UpdateEmission(mainTexture.Texture, mainTexture.Scale, mainTexture.Offset);
         UpdateOcclusion();
         UpdateOutline();
         UpdateShadowRamp();
 
         return Xiexe;
+    }
+
+    private MainTextureData GetMainTexture()
+    {
+        var defaultData = new MainTextureData(
+            Material.mainTexture,
+            Material.GetColor("_Color"),
+            Material.mainTextureScale,
+            Material.mainTextureOffset);
+
+        var shouldBakeMain = Material.GetVector("_MainTexHSVG") != new Vector4(0, 1, 1, 1)
+            && Material.GetFloat("_MainGradationStrength") != 0;
+        
+        // Non-UV0 2nd/3rd textures cannot be preserved in a single UV0 bake.
+        // Null layer textures still bake as white, matching lilToon's editor baker.
+        var shouldBakeMain2nd = Material.GetFloat("_UseMain2ndTex") != 0
+            && (Material.GetTexture("_Main2ndTex") == null
+                || Material.GetFloat("_Main2ndTex_UVMode") == 0);
+        var shouldBakeMain3rd = Material.GetFloat("_UseMain3rdTex") != 0
+            && (Material.GetTexture("_Main3rdTex") == null
+                || Material.GetFloat("_Main3rdTex_UVMode") == 0);
+
+        var shouldBakeAlpha = Material.GetFloat("_AlphaMaskMode") != 0
+            && Material.GetTexture("_AlphaMask") != null;
+
+        if (!shouldBakeMain && !shouldBakeMain2nd && !shouldBakeMain3rd && !shouldBakeAlpha)
+        {
+            return defaultData;
+        }
+
+        var bakerShader = UnityEngine.Shader.Find("Hidden/ltsother_baker");
+        if (bakerShader == null)
+        {
+            UnityEngine.Debug.LogWarning("Could not find lilToon main texture baker shader Hidden/ltsother_baker.");
+            return defaultData;
+        }
+
+        UnityEngine.Texture2D bakedTexture = null;
+        UnityEngine.Material bakerMaterial = null;
+
+        try
+        {
+            bakerMaterial = new UnityEngine.Material(bakerShader);
+            bakerMaterial.CopyPropertiesFromMaterial(Material);
+
+            if (!shouldBakeMain2nd)
+            {
+                bakerMaterial.SetFloat("_UseMain2ndTex", 0);
+            }
+            if (!shouldBakeMain3rd)
+            {
+                bakerMaterial.SetFloat("_UseMain3rdTex", 0);
+            }
+
+            var sourceTexture2D = Material.mainTexture ?? UnityEngine.Texture2D.whiteTexture;
+            if (shouldBakeMain || shouldBakeMain2nd || shouldBakeMain3rd)
+            {
+                bakedTexture = BakeMaterialToTexture(sourceTexture2D, bakerMaterial);
+                bakedTexture.name = $"{Material.name}_MainTex_Baked";
+            }
+
+            if (shouldBakeAlpha)
+            {
+                var alphaSourceTexture = sourceTexture2D;
+                bakerMaterial.EnableKeyword("_ALPHAMASK");
+                if (bakedTexture != null)
+                {
+                    bakerMaterial.SetTexture("_MainTex", alphaSourceTexture);
+                    bakerMaterial.SetColor("_Color", Color.white);
+                    bakerMaterial.SetTextureScale("_MainTex", Vector2.one);
+                    bakerMaterial.SetTextureOffset("_MainTex", Vector2.zero);
+                    bakerMaterial.SetFloat("_UseMain2ndTex", 0);
+                    bakerMaterial.SetFloat("_UseMain3rdTex", 0);
+                    alphaSourceTexture = bakedTexture;
+                }
+
+                var alphaBakedTexture = BakeMaterialToTexture(alphaSourceTexture, bakerMaterial);
+                alphaBakedTexture.name = $"{Material.name}_MainTex_Baked";
+                if (bakedTexture != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(bakedTexture);
+                }
+                bakedTexture = alphaBakedTexture;
+            }
+        }
+        catch (Exception exception)
+        {
+            if (bakedTexture != null)
+            {
+                UnityEngine.Object.DestroyImmediate(bakedTexture);
+            }
+
+            UnityEngine.Debug.LogWarning($"Could not bake lilToon main texture. {exception.Message}");
+            return defaultData;
+        }
+        finally
+        {
+            if (bakerMaterial != null)
+            {
+                UnityEngine.Object.DestroyImmediate(bakerMaterial);
+            }
+        }
+
+        if (bakedTexture == null)
+        {
+            return defaultData;
+        }
+
+        if (AssetCache.MainTexture != null && AssetCache.MainTexture != bakedTexture && !EditorUtility.IsPersistent(AssetCache.MainTexture))
+        {
+            UnityEngine.Object.DestroyImmediate(AssetCache.MainTexture);
+        }
+
+        AssetCache.MainTexture = bakedTexture;
+        return new MainTextureData(bakedTexture,
+            Color.white,
+            Vector2.one,
+            Vector2.zero);
+    }
+
+    private void UpdateMainTexture(MainTextureData mainTextureData)
+    {
+        Xiexe.MainTexture = Context.GetITexture2D(mainTextureData.Texture);
+        Xiexe.MainTextureScale = mainTextureData.Scale;
+        Xiexe.MainTextureOffset = mainTextureData.Offset;
+        Xiexe.Color = mainTextureData.Color.ToColorX_sRGB();
     }
 
     private void UpdateEmission(Texture mainTexture, Vector2 mainTextureScale, Vector2 mainTextureOffset)
@@ -147,7 +284,7 @@ public class LilToonXiexeConverter
                 ?? emissionBlendMask as UnityEngine.Texture2D
                 ?? mainTexture as UnityEngine.Texture2D
                 ?? UnityEngine.Texture2D.whiteTexture;
-            bakedTexture = BakeMaterialToTexture(sourceTexture2D, bakerMaterial, emissionMap.width, emissionMap.height);
+            bakedTexture = BakeMaterialToTexture(sourceTexture2D, bakerMaterial);
             bakedTexture.name = $"{Material.name}_EmissionMap_Baked";
             bakedTexture.wrapMode = emissionMap.wrapMode;
             bakedTexture.filterMode = emissionMap.filterMode;
@@ -324,7 +461,7 @@ public class LilToonXiexeConverter
         }
     }
 
-    private static UnityEngine.Texture2D BakeMaterialToTexture(Texture sourceTexture, UnityEngine.Material material, int width, int height)
+    private static UnityEngine.Texture2D BakeMaterialToTexture(Texture sourceTexture, UnityEngine.Material material)
     {
         UnityEngine.RenderTexture renderTexture = null;
         UnityEngine.Texture2D bakedTexture = null;
@@ -332,12 +469,12 @@ public class LilToonXiexeConverter
 
         try
         {
-            renderTexture = UnityEngine.RenderTexture.GetTemporary(width, height);
+            renderTexture = UnityEngine.RenderTexture.GetTemporary(sourceTexture.width, sourceTexture.height);
             Graphics.Blit(sourceTexture, renderTexture, material);
             UnityEngine.RenderTexture.active = renderTexture;
 
-            bakedTexture = new UnityEngine.Texture2D(width, height);
-            bakedTexture.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+            bakedTexture = new UnityEngine.Texture2D(sourceTexture.width, sourceTexture.height);
+            bakedTexture.ReadPixels(new Rect(0, 0, sourceTexture.width, sourceTexture.height), 0, 0);
             bakedTexture.Apply();
 
             return bakedTexture;

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -473,7 +473,7 @@ public class LilToonXiexeConverter
     {
         if (Material.GetFloat("_UseShadow") == 0)
         {
-            Xiexe.OcclusionColor = Color.black.ToColorX_sRGB();
+            Xiexe.OcclusionMap = null;
             return;
         }
 
@@ -507,6 +507,7 @@ public class LilToonXiexeConverter
     {
         if (Material.GetFloat("_UseShadow") == 0)
         {
+            Xiexe.ShadowRamp = null;
             return;
         }
 

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -64,31 +64,25 @@ public class LilToonXiexeConverter
         var emissionMap = Material.GetTexture("_EmissionMap");
         var emissionBlendMask = Material.GetTexture("_EmissionBlendMask");
         var emissionMapUV = (int)Material.GetFloat("_EmissionMap_UVMode");
+        var emissionMainStrength = Material.GetFloat("_EmissionMainStrength");
 
-        if (emissionMap == null && emissionBlendMask == null)
+        var hasEmissionMap = emissionMap != null;
+        var hasEmissionBlendMask = emissionBlendMask != null;
+        var usesMainTextureAsEmission = emissionMainStrength > 0 && mainTexture != null;
+
+        if (!hasEmissionMap && !hasEmissionBlendMask && !usesMainTextureAsEmission)
         {
             Xiexe.EmissionMap = Context.GetITexture2D(UnityEngine.Texture2D.whiteTexture);
-            Xiexe.EmissionMapScale = Vector2.one;
-            Xiexe.EmissionMapOffset = Vector2.zero;
-            Xiexe.EmissionUV = 0;
-            return;
-        }
-        if (emissionMap == null && emissionBlendMask != null)
-        {
-            Xiexe.EmissionMap = Context.GetITexture2D(emissionBlendMask);
-            Xiexe.EmissionMapScale = Material.GetTextureScale("_EmissionBlendMask");
-            Xiexe.EmissionMapOffset = Material.GetTextureOffset("_EmissionBlendMask");
-            Xiexe.EmissionUV = 0;
             return;
         }
 
-        Xiexe.EmissionMap = Context.GetITexture2D(emissionMap);
-        Xiexe.EmissionMapScale = Material.GetTextureScale("_EmissionMap");
-        Xiexe.EmissionMapOffset = Material.GetTextureOffset("_EmissionMap");
-        Xiexe.EmissionUV = emissionMapUV;
-
-        if (emissionMap != null && (emissionBlendMask == null || emissionMapUV != 0))
+        // If the emission map is not UV0, baking will cause issues, so do not bake.
+        if (hasEmissionMap && emissionMapUV != 0)
         {
+            Xiexe.EmissionMap = Context.GetITexture2D(emissionMap);
+            Xiexe.EmissionMapScale = Material.GetTextureScale("_EmissionMap");
+            Xiexe.EmissionMapOffset = Material.GetTextureOffset("_EmissionMap");
+            Xiexe.EmissionUV = emissionMapUV;
             return;
         }
 
@@ -96,6 +90,20 @@ public class LilToonXiexeConverter
         if (bakerShader == null)
         {
             UnityEngine.Debug.LogWarning("Could not find lilToon texture baker shader Hidden/ltsother_baker.");
+            if (hasEmissionMap)
+            {
+                Xiexe.EmissionMap = Context.GetITexture2D(emissionMap);
+                Xiexe.EmissionMapScale = Material.GetTextureScale("_EmissionMap");
+                Xiexe.EmissionMapOffset = Material.GetTextureOffset("_EmissionMap");
+                Xiexe.EmissionUV = emissionMapUV;
+            }
+            else
+            {
+                Xiexe.EmissionMap = Context.GetITexture2D(emissionBlendMask ?? mainTexture ?? UnityEngine.Texture2D.whiteTexture);
+                Xiexe.EmissionMapScale = Vector2.one;
+                Xiexe.EmissionMapOffset = Vector2.zero;
+                Xiexe.EmissionUV = 0;
+            }
             return;
         }
 
@@ -106,27 +114,40 @@ public class LilToonXiexeConverter
         {
             bakerMaterial = new UnityEngine.Material(bakerShader);
             bakerMaterial.SetColor("_Color", Color.white);
-            bakerMaterial.SetTexture("_MainTex", emissionMap);
-            bakerMaterial.SetTextureScale("_MainTex", Material.GetTextureScale("_EmissionMap"));
-            bakerMaterial.SetTextureOffset("_MainTex", Material.GetTextureOffset("_EmissionMap"));
-            bakerMaterial.SetFloat("_UseMain2ndTex", 1);
-            bakerMaterial.SetColor("_Color2nd", Color.white);
-            bakerMaterial.SetTexture("_Main2ndTex", emissionBlendMask);
-            bakerMaterial.SetTextureScale("_Main2ndTex", Material.GetTextureScale("_EmissionBlendMask"));
-            bakerMaterial.SetTextureOffset("_Main2ndTex", Material.GetTextureOffset("_EmissionBlendMask"));
-            bakerMaterial.SetFloat("_Main2ndTexBlendMode", 3);
-            var emissionMainStrength = Mathf.Clamp01(Material.GetFloat("_EmissionMainStrength"));
-            if (emissionMainStrength > 0 && mainTexture != null)
+            if (hasEmissionMap)
+            {
+                bakerMaterial.SetTexture("_MainTex", emissionMap);
+                bakerMaterial.SetTextureScale("_MainTex", Material.GetTextureScale("_EmissionMap"));
+                bakerMaterial.SetTextureOffset("_MainTex", Material.GetTextureOffset("_EmissionMap"));
+            }
+            else
+            {
+                bakerMaterial.SetTexture("_MainTex", UnityEngine.Texture2D.whiteTexture);
+            }
+            if (hasEmissionBlendMask)
+            {
+                bakerMaterial.SetFloat("_UseMain2ndTex", 1);
+                bakerMaterial.SetColor("_Color2nd", Color.white);
+                bakerMaterial.SetTexture("_Main2ndTex", emissionBlendMask);
+                bakerMaterial.SetTextureScale("_Main2ndTex", Material.GetTextureScale("_EmissionBlendMask"));
+                bakerMaterial.SetTextureOffset("_Main2ndTex", Material.GetTextureOffset("_EmissionBlendMask"));
+                bakerMaterial.SetFloat("_Main2ndTexBlendMode", 3);  // Multiply
+            }
+            if (usesMainTextureAsEmission)
             {
                 bakerMaterial.SetFloat("_UseMain3rdTex", 1);
-                bakerMaterial.SetColor("_Color3rd", new Color(1, 1, 1, emissionMainStrength));
+                bakerMaterial.SetColor("_Color3rd", new Color(1, 1, 1, Mathf.Clamp01(emissionMainStrength)));
                 bakerMaterial.SetTexture("_Main3rdTex", mainTexture);
                 bakerMaterial.SetTextureScale("_Main3rdTex", mainTextureScale);
                 bakerMaterial.SetTextureOffset("_Main3rdTex", mainTextureOffset);
-                bakerMaterial.SetFloat("_Main3rdTexBlendMode", 3);
+                bakerMaterial.SetFloat("_Main3rdTexBlendMode", 3);  // Multiply
             }
 
-            bakedTexture = BakeMaterialToTexture(emissionMap, bakerMaterial, emissionMap.width, emissionMap.height);
+            var sourceTexture2D = emissionMap as UnityEngine.Texture2D
+                ?? emissionBlendMask as UnityEngine.Texture2D
+                ?? mainTexture as UnityEngine.Texture2D
+                ?? UnityEngine.Texture2D.whiteTexture;
+            bakedTexture = BakeMaterialToTexture(sourceTexture2D, bakerMaterial, emissionMap.width, emissionMap.height);
             bakedTexture.name = $"{Material.name}_EmissionMap_Baked";
             bakedTexture.wrapMode = emissionMap.wrapMode;
             bakedTexture.filterMode = emissionMap.filterMode;

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -59,7 +59,7 @@ public class LilToonXiexeConverter
             Material.mainTextureOffset);
 
         var shouldBakeMain = Material.GetVector("_MainTexHSVG") != new Vector4(0, 1, 1, 1)
-            && Material.GetFloat("_MainGradationStrength") != 0;
+            || Material.GetFloat("_MainGradationStrength") != 0;
         
         // Non-UV0 2nd/3rd textures cannot be preserved in a single UV0 bake.
         // Null layer textures still bake as white, matching lilToon's editor baker.

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -39,12 +39,13 @@ public class LilToonXiexeConverter
         var mainTexture = GetMainTexture();
         UpdateMainTexture(mainTexture);
         UpdateRenderSettings();
-        Xiexe.ShadowRim = Color.white.ToColorX_sRGB();
+        UpdateNormal();
         UpdateEmission(mainTexture.Texture, mainTexture.Scale, mainTexture.Offset);
         UpdateMatcap();
         UpdateOcclusion();
         UpdateOutline();
         UpdateShadowRamp();
+        Xiexe.ShadowRim = Color.white.ToColorX_sRGB();
 
         return Xiexe;
     }
@@ -261,6 +262,31 @@ public class LilToonXiexeConverter
         return shaderName.IndexOf(subName, separatorIndex + 1) != -1;
     }
  
+    private void UpdateNormal()
+    {
+        // TODO: If 2nd normal map support is added, bake into a single normal map
+        if (Material.GetFloat("_UseBumpMap") != 0)
+        {
+            Xiexe.NormalMap = Context.GetITexture2D(Material.GetTexture("_BumpMap"));
+            Xiexe.NormalMapOffset = Material.GetTextureOffset("_BumpMap");
+            Xiexe.NormalMapScale = Material.GetTextureScale("_BumpMap");
+            Xiexe.NormalScale = Material.GetFloat("_BumpScale");
+            Xiexe.NormalUV = 0;
+            return;
+        }
+        if (Material.GetFloat("_UseBump2ndMap") != 0)
+        {
+            // TODO: _Bump2ndScaleMask is not supported, so the 2nd normal map's strength may differ from lilToon. Consider baking if this causes issues.
+            Xiexe.NormalMap = Context.GetITexture2D(Material.GetTexture("_Bump2ndMap"));
+            Xiexe.NormalMapOffset = Material.GetTextureOffset("_Bump2ndMap");
+            Xiexe.NormalMapScale = Material.GetTextureScale("_Bump2ndMap");
+            Xiexe.NormalScale = Material.GetFloat("_Bump2ndScale");
+            Xiexe.NormalUV = (int)Material.GetFloat("_Bump2ndMap_UVMode");
+            return;
+        }
+        Xiexe.NormalMap = null;
+    }
+
     private void UpdateEmission(Texture mainTexture, Vector2 mainTextureScale, Vector2 mainTextureOffset)
     {
         if (Material.GetFloat("_UseEmission") == 0)

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -49,7 +49,7 @@ public class LilToonXiexeConverter
 
         var emissionColor = Material.GetColor("_EmissionColor");
         var emissionFluorescence = Mathf.Clamp01(Material.GetFloat("_EmissionFluorescence"));
-        if (emissionFluorescence != 0)
+        if (emissionFluorescence > 0)
         {
             // lilToon multiplies fluorescence emission by a lighting-dependent
             // invLighting value. Xiexe emission is static, so use the maximum-ish
@@ -59,7 +59,7 @@ public class LilToonXiexeConverter
             emissionColor.g *= fluorescenceScale;
             emissionColor.b *= fluorescenceScale;
         }
-        Xiexe.EmissionColor = emissionColor.ToColorX_sRGB();
+        Xiexe.EmissionColor = emissionColor.ToColorX_Linear();
 
         var emissionMap = Material.GetTexture("_EmissionMap");
         var emissionBlendMask = Material.GetTexture("_EmissionBlendMask");

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -1,5 +1,7 @@
+using System;
 using FrooxEngine;
 using UnityEngine;
+using UnityEditor;
 
 public class LilToonXiexeConverter
 {
@@ -26,8 +28,116 @@ public class LilToonXiexeConverter
         Xiexe.ShadowRim = Color.white.ToColorX_sRGB();
         Xiexe.ColorMask = (ColorMask)Material.GetFloat("_ColorMask");
         Xiexe.RenderQueue = Material.renderQueue;
+        UpdateShadowRamp();
 
         return Xiexe;
+    }
+
+    private void UpdateShadowRamp()
+    {
+        if (Material.GetFloat("_UseShadow") == 0)
+        {
+            return;
+        }
+
+        var bakerShader = UnityEngine.Shader.Find("Hidden/ltsother_bakeramp");
+        if (bakerShader == null)
+        {
+            UnityEngine.Debug.LogWarning("Could not find lilToon shadow ramp baker shader Hidden/ltsother_bakeramp.");
+            return;
+        }
+
+        UnityEngine.Material bakerMaterial = null;
+        UnityEngine.Texture2D bakedRamp = null;
+        UnityEngine.RenderTexture renderTexture = null;
+        var currentRenderTexture = UnityEngine.RenderTexture.active;
+
+        try
+        {
+            const int width = 256;
+            const int height = 256;
+            const int sourceHeight = 1;
+            // Avoid assigning source.shader on Material Variants. Copy the saved values
+            // into a normal baker material that already uses Hidden/ltsother_bakeramp.
+            bakerMaterial = new UnityEngine.Material(bakerShader);
+            bakerMaterial.CopyPropertiesFromMaterial(Material);
+
+            // Bake lilToon's horizontal shadow ramp into the first row.
+            renderTexture = UnityEngine.RenderTexture.GetTemporary(width, sourceHeight, 0, UnityEngine.RenderTextureFormat.Default, UnityEngine.RenderTextureReadWrite.Default);
+            UnityEngine.RenderTexture.active = renderTexture;
+            Graphics.Blit(null, renderTexture, bakerMaterial);
+
+            bakedRamp = new UnityEngine.Texture2D(width, height, TextureFormat.RGBA32, false, false)
+            {
+                name = "LilToonConverter baked shadow ramp",
+                wrapMode = TextureWrapMode.Clamp,
+            };
+            bakedRamp.ReadPixels(new Rect(0, 0, width, sourceHeight), 0, 0);
+
+            // Expand the horizontal ramp vertically so Xiexe's ShadowRampMask can sample it.
+            var sourcePixels = bakedRamp.GetPixels(0, 0, width, 1);
+            var gradientPixels = new Color[width * height];
+
+            for (var y = 0; y < height; y++)
+            {
+                var mask = height > 1 ? y / (height - 1f) : 1f;
+                for (var x = 0; x < width; x++)
+                {
+                    var color = Color.Lerp(Color.white, sourcePixels[x], mask);
+                    gradientPixels[x + y * width] = color;
+                }
+            }
+
+            bakedRamp.SetPixels(gradientPixels);
+            bakedRamp.Apply();
+        }
+        catch (Exception exception)
+        {
+            if (bakedRamp != null)
+            {
+                UnityEngine.Object.DestroyImmediate(bakedRamp);
+            }
+
+            UnityEngine.Debug.LogWarning($"Could not bake lilToon shadow ramp. {exception.Message}");
+            return;
+        }
+        finally
+        {
+            UnityEngine.RenderTexture.active = currentRenderTexture;
+            if (renderTexture != null)
+            {
+                UnityEngine.RenderTexture.ReleaseTemporary(renderTexture);
+            }
+
+            if (bakerMaterial != null)
+            {
+                UnityEngine.Object.DestroyImmediate(bakerMaterial);
+            }
+        }
+
+        if (AssetCache.ShadowRampTexture != null && AssetCache.ShadowRampTexture != bakedRamp && !EditorUtility.IsPersistent(AssetCache.ShadowRampTexture))
+        {
+            UnityEngine.Object.DestroyImmediate(AssetCache.ShadowRampTexture);
+        }
+
+        AssetCache.ShadowRampTexture = bakedRamp;
+
+        Xiexe.ShadowRamp = Context.GetITexture2D(bakedRamp);
+        // XiexeToon's null ShadowRampMask behaves differently from lilToon's null
+        // _ShadowStrengthMask, which means no shadow strength mask. Preserve that with white.
+        if (Material.GetTexture("_ShadowStrengthMask") == null)
+        {
+            Xiexe.ShadowRampMask = Context.GetITexture2D(UnityEngine.Texture2D.whiteTexture);
+            Xiexe.ShadowRampMaskScale = Vector2.one;
+            Xiexe.ShadowRampMaskOffset = Vector2.zero;
+            return;
+        }
+        else
+        {
+            Xiexe.ShadowRampMask = Context.GetITexture2D(Material.GetTexture("_ShadowStrengthMask"));
+            Xiexe.ShadowRampMaskScale = Material.GetTextureScale("_ShadowStrengthMask");
+            Xiexe.ShadowRampMaskOffset = Material.GetTextureOffset("_ShadowStrengthMask");
+        }
     }
 
 }

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -21,6 +21,22 @@ public class LilToonXiexeConverter
         }
     }
 
+    private struct EmissionMapData
+    {
+        public readonly Texture Texture;
+        public readonly Vector2 Scale;
+        public readonly Vector2 Offset;
+        public readonly int UV;
+
+        public EmissionMapData(Texture texture, Vector2 scale, Vector2 offset, int uv)
+        {
+            Texture = texture;
+            Scale = scale;
+            Offset = offset;
+            UV = uv;
+        }
+    }
+
     private readonly XiexeToonMaterial Xiexe;
     private readonly UnityEngine.Material Material;
     private readonly IConversionContext Context;
@@ -76,6 +92,15 @@ public class LilToonXiexeConverter
         if (!shouldBakeMain && !shouldBakeMain2nd && !shouldBakeMain3rd && !shouldBakeAlpha)
         {
             return defaultData;
+        }
+
+        var bakeHash = GetMainTextureBakeHash(shouldBakeMain, shouldBakeMain2nd, shouldBakeMain3rd, shouldBakeAlpha);
+        if (AssetCache.MainTexture != null && AssetCache.MainTextureBakeHash == bakeHash)
+        {
+            return new MainTextureData(AssetCache.MainTexture,
+                Color.white,
+                Vector2.one,
+                Vector2.zero);
         }
 
         var bakerShader = UnityEngine.Shader.Find("Hidden/ltsother_baker");
@@ -162,6 +187,7 @@ public class LilToonXiexeConverter
         }
 
         AssetCache.MainTexture = bakedTexture;
+        AssetCache.MainTextureBakeHash = bakeHash;
         return new MainTextureData(bakedTexture,
             Color.white,
             Vector2.one,
@@ -313,6 +339,24 @@ public class LilToonXiexeConverter
         }
         Xiexe.EmissionColor = emissionColor.ToColorX_Linear();
 
+        var emissionMap = GetEmissionMap(mainTexture, mainTextureScale, mainTextureOffset);
+        Xiexe.EmissionMap = Context.GetITexture2D(emissionMap.Texture, OpacifyProcessor);
+        Xiexe.EmissionMapScale = emissionMap.Scale;
+        Xiexe.EmissionMapOffset = emissionMap.Offset;
+        Xiexe.EmissionUV = emissionMap.UV;
+    }
+
+    private EmissionMapData GetEmissionMap(Texture mainTexture, Vector2 mainTextureScale, Vector2 mainTextureOffset)
+    {
+        var bakeHash = GetEmissionMapBakeHash(
+            mainTexture,
+            mainTextureScale,
+            mainTextureOffset);
+        if (AssetCache.EmissionMap != null && AssetCache.EmissionMapBakeHash == bakeHash)
+        {
+            return new EmissionMapData(AssetCache.EmissionMap, Vector2.one, Vector2.zero, 0);
+        }
+
         var emissionMap = Material.GetTexture("_EmissionMap");
         var emissionBlendMask = Material.GetTexture("_EmissionBlendMask");
         var emissionMapUV = (int)Material.GetFloat("_EmissionMap_UVMode");
@@ -322,41 +366,34 @@ public class LilToonXiexeConverter
         var hasEmissionBlendMask = emissionBlendMask != null;
         var usesMainTextureAsEmission = emissionMainStrength > 0 && mainTexture != null;
 
+        var fallbackData = hasEmissionMap
+            ? new EmissionMapData(
+                emissionMap,
+                Material.GetTextureScale("_EmissionMap"),
+                Material.GetTextureOffset("_EmissionMap"),
+                emissionMapUV)
+            : new EmissionMapData(
+                emissionBlendMask ?? mainTexture ?? UnityEngine.Texture2D.whiteTexture,
+                Vector2.one,
+                Vector2.zero,
+                0);
+
         if (!hasEmissionMap && !hasEmissionBlendMask && !usesMainTextureAsEmission)
         {
-            Xiexe.EmissionMap = Context.GetITexture2D(UnityEngine.Texture2D.whiteTexture);
-            return;
+            return fallbackData;
         }
 
         // If the emission map is not UV0, baking will cause issues, so do not bake.
         if (hasEmissionMap && emissionMapUV != 0)
         {
-            Xiexe.EmissionMap = Context.GetITexture2D(emissionMap, OpacifyProcessor);
-            Xiexe.EmissionMapScale = Material.GetTextureScale("_EmissionMap");
-            Xiexe.EmissionMapOffset = Material.GetTextureOffset("_EmissionMap");
-            Xiexe.EmissionUV = emissionMapUV;
-            return;
+            return fallbackData;
         }
 
         var bakerShader = UnityEngine.Shader.Find("Hidden/ltsother_baker");
         if (bakerShader == null)
         {
             UnityEngine.Debug.LogWarning("Could not find lilToon texture baker shader Hidden/ltsother_baker.");
-            if (hasEmissionMap)
-            {
-                Xiexe.EmissionMap = Context.GetITexture2D(emissionMap, OpacifyProcessor);
-                Xiexe.EmissionMapScale = Material.GetTextureScale("_EmissionMap");
-                Xiexe.EmissionMapOffset = Material.GetTextureOffset("_EmissionMap");
-                Xiexe.EmissionUV = emissionMapUV;
-            }
-            else
-            {
-                Xiexe.EmissionMap = Context.GetITexture2D(emissionBlendMask ?? mainTexture ?? UnityEngine.Texture2D.whiteTexture);
-                Xiexe.EmissionMapScale = Vector2.one;
-                Xiexe.EmissionMapOffset = Vector2.zero;
-                Xiexe.EmissionUV = 0;
-            }
-            return;
+            return fallbackData;
         }
 
         UnityEngine.Texture2D bakedTexture = null;
@@ -413,7 +450,7 @@ public class LilToonXiexeConverter
             }
 
             UnityEngine.Debug.LogWarning($"Could not bake lilToon emission map. {exception.Message}");
-            return;
+            return fallbackData;
         }
         finally
         {
@@ -429,10 +466,8 @@ public class LilToonXiexeConverter
         }
 
         AssetCache.EmissionMap = bakedTexture;
-        Xiexe.EmissionMap = Context.GetITexture2D(bakedTexture, OpacifyProcessor);
-        Xiexe.EmissionMapScale = Vector2.one;
-        Xiexe.EmissionMapOffset = Vector2.zero;
-        Xiexe.EmissionUV = 0;
+        AssetCache.EmissionMapBakeHash = bakeHash;
+        return new EmissionMapData(bakedTexture, Vector2.one, Vector2.zero, 0);
     }
 
     private void UpdateMatcap()
@@ -511,11 +546,38 @@ public class LilToonXiexeConverter
             return;
         }
 
+        // XiexeToon's null ShadowRampMask behaves differently from lilToon's null
+        // _ShadowStrengthMask, which means no shadow strength mask. Preserve that with white.
+        if (Material.GetTexture("_ShadowStrengthMask") == null)
+        {
+            Xiexe.ShadowRampMask = Context.GetITexture2D(UnityEngine.Texture2D.whiteTexture);
+            Xiexe.ShadowRampMaskScale = Vector2.one;
+            Xiexe.ShadowRampMaskOffset = Vector2.zero;
+        }
+        else
+        {
+            Xiexe.ShadowRampMask = Context.GetITexture2D(Material.GetTexture("_ShadowStrengthMask"));
+            Xiexe.ShadowRampMaskScale = Material.GetTextureScale("_ShadowStrengthMask");
+            Xiexe.ShadowRampMaskOffset = Material.GetTextureOffset("_ShadowStrengthMask");
+        }
+
+        var shadowRamp = GetShadowRamp();
+        Xiexe.ShadowRamp = Context.GetITexture2D(shadowRamp);
+    }
+
+    private UnityEngine.Texture2D GetShadowRamp()
+    {
+        var bakeHash = GetShadowRampBakeHash();
+        if (AssetCache.ShadowRampTexture != null && AssetCache.ShadowRampBakeHash == bakeHash)
+        {
+            return AssetCache.ShadowRampTexture;
+        }
+
         var bakerShader = UnityEngine.Shader.Find("Hidden/ltsother_bakeramp");
         if (bakerShader == null)
         {
             UnityEngine.Debug.LogWarning("Could not find lilToon shadow ramp baker shader Hidden/ltsother_bakeramp.");
-            return;
+            return null;
         }
 
         UnityEngine.Material bakerMaterial = null;
@@ -570,7 +632,7 @@ public class LilToonXiexeConverter
             }
 
             UnityEngine.Debug.LogWarning($"Could not bake lilToon shadow ramp. {exception.Message}");
-            return;
+            return null;
         }
         finally
         {
@@ -592,23 +654,129 @@ public class LilToonXiexeConverter
         }
 
         AssetCache.ShadowRampTexture = bakedRamp;
+        AssetCache.ShadowRampBakeHash = bakeHash;
+        return bakedRamp;
+    }
 
-        Xiexe.ShadowRamp = Context.GetITexture2D(bakedRamp);
-        // XiexeToon's null ShadowRampMask behaves differently from lilToon's null
-        // _ShadowStrengthMask, which means no shadow strength mask. Preserve that with white.
-        if (Material.GetTexture("_ShadowStrengthMask") == null)
+    private Hash128 GetMainTextureBakeHash(bool shouldBakeMain, bool shouldBakeMain2nd, bool shouldBakeMain3rd, bool shouldBakeAlpha)
+    {
+        var hash = new LilToonAssetCache.BakeHash();
+        hash.Add(shouldBakeMain);
+        hash.Add(shouldBakeMain2nd);
+        hash.Add(shouldBakeMain3rd);
+        hash.Add(shouldBakeAlpha);
+        hash.Add(Material.mainTexture);
+
+        if (shouldBakeMain || shouldBakeMain2nd || shouldBakeMain3rd)
         {
-            Xiexe.ShadowRampMask = Context.GetITexture2D(UnityEngine.Texture2D.whiteTexture);
-            Xiexe.ShadowRampMaskScale = Vector2.one;
-            Xiexe.ShadowRampMaskOffset = Vector2.zero;
-            return;
+            hash.Add(Material.mainTextureScale);
+            hash.Add(Material.mainTextureOffset);
+            hash.Add(Material.GetColor("_Color"));
+            hash.Add(Material.GetVector("_MainTexHSVG"));
+            hash.Add(Material.GetFloat("_MainGradationStrength"));
+            hash.Add(Material.GetTexture("_MainGradationTex"));
+            hash.Add(Material.GetTextureScale("_MainGradationTex"));
+            hash.Add(Material.GetTextureOffset("_MainGradationTex"));
+            hash.Add(Material.GetTexture("_MainColorAdjustMask"));
+            hash.Add(Material.GetTextureScale("_MainColorAdjustMask"));
+            hash.Add(Material.GetTextureOffset("_MainColorAdjustMask"));
         }
-        else
+
+        if (shouldBakeMain2nd)
         {
-            Xiexe.ShadowRampMask = Context.GetITexture2D(Material.GetTexture("_ShadowStrengthMask"));
-            Xiexe.ShadowRampMaskScale = Material.GetTextureScale("_ShadowStrengthMask");
-            Xiexe.ShadowRampMaskOffset = Material.GetTextureOffset("_ShadowStrengthMask");
+            AddMainLayerBakeHash(ref hash, "2nd");
         }
+        if (shouldBakeMain3rd)
+        {
+            AddMainLayerBakeHash(ref hash, "3rd");
+        }
+        if (shouldBakeAlpha)
+        {
+            hash.Add(Material.GetFloat("_AlphaMaskMode"));
+            hash.Add(Material.GetTexture("_AlphaMask"));
+            hash.Add(Material.GetTextureScale("_AlphaMask"));
+            hash.Add(Material.GetTextureOffset("_AlphaMask"));
+            hash.Add(Material.GetFloat("_AlphaMaskScale"));
+            hash.Add(Material.GetFloat("_AlphaMaskValue"));
+        }
+        return hash.Value;
+    }
+
+    private void AddMainLayerBakeHash(ref LilToonAssetCache.BakeHash hash, string suffix)
+    {
+        var prefix = $"_Main{suffix}";
+        hash.Add(Material.GetFloat($"_UseMain{suffix}Tex"));
+        hash.Add(Material.GetColor($"_Color{suffix}"));
+        hash.Add(Material.GetTexture($"{prefix}Tex"));
+        hash.Add(Material.GetTextureScale($"{prefix}Tex"));
+        hash.Add(Material.GetTextureOffset($"{prefix}Tex"));
+        hash.Add(Material.GetFloat($"{prefix}Tex_UVMode"));
+        hash.Add(Material.GetFloat($"{prefix}TexAngle"));
+        hash.Add(Material.GetVector($"{prefix}TexDecalAnimation"));
+        hash.Add(Material.GetVector($"{prefix}TexDecalSubParam"));
+        hash.Add(Material.GetFloat($"{prefix}TexIsDecal"));
+        hash.Add(Material.GetFloat($"{prefix}TexIsLeftOnly"));
+        hash.Add(Material.GetFloat($"{prefix}TexIsRightOnly"));
+        hash.Add(Material.GetFloat($"{prefix}TexShouldCopy"));
+        hash.Add(Material.GetFloat($"{prefix}TexShouldFlipMirror"));
+        hash.Add(Material.GetFloat($"{prefix}TexShouldFlipCopy"));
+        hash.Add(Material.GetFloat($"{prefix}TexIsMSDF"));
+        hash.Add(Material.GetTexture($"{prefix}BlendMask"));
+        hash.Add(Material.GetTextureScale($"{prefix}BlendMask"));
+        hash.Add(Material.GetTextureOffset($"{prefix}BlendMask"));
+        hash.Add(Material.GetFloat($"{prefix}TexBlendMode"));
+    }
+
+    private Hash128 GetEmissionMapBakeHash(
+        Texture mainTexture,
+        Vector2 mainTextureScale,
+        Vector2 mainTextureOffset)
+    {
+        var emissionMap = Material.GetTexture("_EmissionMap");
+        var emissionBlendMask = Material.GetTexture("_EmissionBlendMask");
+        var usesMainTextureAsEmission = Material.GetFloat("_EmissionMainStrength") > 0 && mainTexture != null;
+        var hash = new LilToonAssetCache.BakeHash();
+        hash.Add(emissionMap != null);
+        hash.Add(emissionBlendMask != null);
+        hash.Add(usesMainTextureAsEmission);
+        if (emissionMap != null)
+        {
+            hash.Add(Material.GetTexture("_EmissionMap"));
+            hash.Add(Material.GetTextureScale("_EmissionMap"));
+            hash.Add(Material.GetTextureOffset("_EmissionMap"));
+        }
+        if (emissionBlendMask != null)
+        {
+            hash.Add(Material.GetTexture("_EmissionBlendMask"));
+            hash.Add(Material.GetTextureScale("_EmissionBlendMask"));
+            hash.Add(Material.GetTextureOffset("_EmissionBlendMask"));
+        }
+        if (usesMainTextureAsEmission)
+        {
+            hash.Add(Material.GetFloat("_EmissionMainStrength"));
+            hash.Add(mainTexture);
+            hash.Add(mainTextureScale);
+            hash.Add(mainTextureOffset);
+        }
+        return hash.Value;
+    }
+
+    private Hash128 GetShadowRampBakeHash()
+    {
+        var hash = new LilToonAssetCache.BakeHash();
+        hash.Add(Material.GetFloat("_ShadowStrength"));
+        hash.Add(Material.GetColor("_ShadowColor"));
+        hash.Add(Material.GetFloat("_ShadowBorder"));
+        hash.Add(Material.GetFloat("_ShadowBlur"));
+        hash.Add(Material.GetColor("_Shadow2ndColor"));
+        hash.Add(Material.GetFloat("_Shadow2ndBorder"));
+        hash.Add(Material.GetFloat("_Shadow2ndBlur"));
+        hash.Add(Material.GetColor("_Shadow3rdColor"));
+        hash.Add(Material.GetFloat("_Shadow3rdBorder"));
+        hash.Add(Material.GetFloat("_Shadow3rdBlur"));
+        hash.Add(Material.GetColor("_ShadowBorderColor"));
+        hash.Add(Material.GetFloat("_ShadowBorderRange"));
+        return hash.Value;
     }
 
     private static UnityEngine.Texture2D BakeMaterialToTexture(Texture sourceTexture, UnityEngine.Material material)

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -20,19 +20,146 @@ public class LilToonXiexeConverter
 
     public IAssetProvider<FrooxEngine.Material> UpdateConversion()
     {
-        Xiexe.MainTexture = Context.GetITexture2D(Material.mainTexture);
-        Xiexe.MainTextureScale = Material.mainTextureScale;
-        Xiexe.MainTextureOffset = Material.mainTextureOffset;
+        var mainTexture = Material.mainTexture;
+        var mainTextureScale = Material.mainTextureScale;
+        var mainTextureOffset = Material.mainTextureOffset;
+        Xiexe.MainTexture = Context.GetITexture2D(mainTexture);
+        Xiexe.MainTextureScale = mainTextureScale;
+        Xiexe.MainTextureOffset = mainTextureOffset;
         Xiexe.Color = Material.GetColor("_Color").ToColorX_sRGB();
         Xiexe.Saturation = 1;
         Xiexe.ShadowRim = Color.white.ToColorX_sRGB();
         Xiexe.ColorMask = (ColorMask)Material.GetFloat("_ColorMask");
         Xiexe.RenderQueue = Material.renderQueue;
+        UpdateEmission(mainTexture, mainTextureScale, mainTextureOffset);
         UpdateOcclusion();
         UpdateOutline();
         UpdateShadowRamp();
 
         return Xiexe;
+    }
+
+    private void UpdateEmission(Texture mainTexture, Vector2 mainTextureScale, Vector2 mainTextureOffset)
+    {
+        if (Material.GetFloat("_UseEmission") == 0)
+        {
+            Xiexe.EmissionMap = null;
+            return;
+        }
+
+        var emissionColor = Material.GetColor("_EmissionColor");
+        var emissionFluorescence = Mathf.Clamp01(Material.GetFloat("_EmissionFluorescence"));
+        if (emissionFluorescence != 0)
+        {
+            // lilToon multiplies fluorescence emission by a lighting-dependent
+            // invLighting value. Xiexe emission is static, so use the maximum-ish
+            // value of lilToon's curve as a conservative approximation.
+            var fluorescenceScale = Mathf.Lerp(1, 0.375f, emissionFluorescence);
+            emissionColor.r *= fluorescenceScale;
+            emissionColor.g *= fluorescenceScale;
+            emissionColor.b *= fluorescenceScale;
+        }
+        Xiexe.EmissionColor = emissionColor.ToColorX_sRGB();
+
+        var emissionMap = Material.GetTexture("_EmissionMap");
+        var emissionBlendMask = Material.GetTexture("_EmissionBlendMask");
+        var emissionMapUV = (int)Material.GetFloat("_EmissionMap_UVMode");
+
+        if (emissionMap == null && emissionBlendMask == null)
+        {
+            Xiexe.EmissionMap = Context.GetITexture2D(UnityEngine.Texture2D.whiteTexture);
+            Xiexe.EmissionMapScale = Vector2.one;
+            Xiexe.EmissionMapOffset = Vector2.zero;
+            Xiexe.EmissionUV = 0;
+            return;
+        }
+        if (emissionMap == null && emissionBlendMask != null)
+        {
+            Xiexe.EmissionMap = Context.GetITexture2D(emissionBlendMask);
+            Xiexe.EmissionMapScale = Material.GetTextureScale("_EmissionBlendMask");
+            Xiexe.EmissionMapOffset = Material.GetTextureOffset("_EmissionBlendMask");
+            Xiexe.EmissionUV = 0;
+            return;
+        }
+
+        Xiexe.EmissionMap = Context.GetITexture2D(emissionMap);
+        Xiexe.EmissionMapScale = Material.GetTextureScale("_EmissionMap");
+        Xiexe.EmissionMapOffset = Material.GetTextureOffset("_EmissionMap");
+        Xiexe.EmissionUV = emissionMapUV;
+
+        if (emissionMap != null && (emissionBlendMask == null || emissionMapUV != 0))
+        {
+            return;
+        }
+
+        var bakerShader = UnityEngine.Shader.Find("Hidden/ltsother_baker");
+        if (bakerShader == null)
+        {
+            UnityEngine.Debug.LogWarning("Could not find lilToon texture baker shader Hidden/ltsother_baker.");
+            return;
+        }
+
+        UnityEngine.Texture2D bakedTexture = null;
+        UnityEngine.Material bakerMaterial = null;
+
+        try
+        {
+            bakerMaterial = new UnityEngine.Material(bakerShader);
+            bakerMaterial.SetColor("_Color", Color.white);
+            bakerMaterial.SetTexture("_MainTex", emissionMap);
+            bakerMaterial.SetTextureScale("_MainTex", Material.GetTextureScale("_EmissionMap"));
+            bakerMaterial.SetTextureOffset("_MainTex", Material.GetTextureOffset("_EmissionMap"));
+            bakerMaterial.SetFloat("_UseMain2ndTex", 1);
+            bakerMaterial.SetColor("_Color2nd", Color.white);
+            bakerMaterial.SetTexture("_Main2ndTex", emissionBlendMask);
+            bakerMaterial.SetTextureScale("_Main2ndTex", Material.GetTextureScale("_EmissionBlendMask"));
+            bakerMaterial.SetTextureOffset("_Main2ndTex", Material.GetTextureOffset("_EmissionBlendMask"));
+            bakerMaterial.SetFloat("_Main2ndTexBlendMode", 3);
+            var emissionMainStrength = Mathf.Clamp01(Material.GetFloat("_EmissionMainStrength"));
+            if (emissionMainStrength > 0 && mainTexture != null)
+            {
+                bakerMaterial.SetFloat("_UseMain3rdTex", 1);
+                bakerMaterial.SetColor("_Color3rd", new Color(1, 1, 1, emissionMainStrength));
+                bakerMaterial.SetTexture("_Main3rdTex", mainTexture);
+                bakerMaterial.SetTextureScale("_Main3rdTex", mainTextureScale);
+                bakerMaterial.SetTextureOffset("_Main3rdTex", mainTextureOffset);
+                bakerMaterial.SetFloat("_Main3rdTexBlendMode", 3);
+            }
+
+            bakedTexture = BakeMaterialToTexture(emissionMap, bakerMaterial, emissionMap.width, emissionMap.height);
+            bakedTexture.name = $"{Material.name}_EmissionMap_Baked";
+            bakedTexture.wrapMode = emissionMap.wrapMode;
+            bakedTexture.filterMode = emissionMap.filterMode;
+            bakedTexture.anisoLevel = emissionMap.anisoLevel;
+        }
+        catch (Exception exception)
+        {
+            if (bakedTexture != null)
+            {
+                UnityEngine.Object.DestroyImmediate(bakedTexture);
+            }
+
+            UnityEngine.Debug.LogWarning($"Could not bake lilToon emission map. {exception.Message}");
+            return;
+        }
+        finally
+        {
+            if (bakerMaterial != null)
+            {
+                UnityEngine.Object.DestroyImmediate(bakerMaterial);
+            }
+        }
+
+        if (AssetCache.EmissionMap != null && AssetCache.EmissionMap != bakedTexture && !EditorUtility.IsPersistent(AssetCache.EmissionMap))
+        {
+            UnityEngine.Object.DestroyImmediate(AssetCache.EmissionMap);
+        }
+
+        AssetCache.EmissionMap = bakedTexture;
+        Xiexe.EmissionMap = Context.GetITexture2D(bakedTexture);
+        Xiexe.EmissionMapScale = Vector2.one;
+        Xiexe.EmissionMapOffset = Vector2.zero;
+        Xiexe.EmissionUV = 0;
     }
 
     private void UpdateOcclusion()
@@ -103,7 +230,7 @@ public class LilToonXiexeConverter
             UnityEngine.RenderTexture.active = renderTexture;
             Graphics.Blit(null, renderTexture, bakerMaterial);
 
-            bakedRamp = new UnityEngine.Texture2D(width, height, TextureFormat.RGBA32, false, false)
+            bakedRamp = new UnityEngine.Texture2D(width, height, TextureFormat.RGBA32, false)
             {
                 name = "LilToonConverter baked shadow ramp",
                 wrapMode = TextureWrapMode.Clamp,
@@ -173,6 +300,43 @@ public class LilToonXiexeConverter
             Xiexe.ShadowRampMask = Context.GetITexture2D(Material.GetTexture("_ShadowStrengthMask"));
             Xiexe.ShadowRampMaskScale = Material.GetTextureScale("_ShadowStrengthMask");
             Xiexe.ShadowRampMaskOffset = Material.GetTextureOffset("_ShadowStrengthMask");
+        }
+    }
+
+    private static UnityEngine.Texture2D BakeMaterialToTexture(Texture sourceTexture, UnityEngine.Material material, int width, int height)
+    {
+        UnityEngine.RenderTexture renderTexture = null;
+        UnityEngine.Texture2D bakedTexture = null;
+        var currentRenderTexture = UnityEngine.RenderTexture.active;
+
+        try
+        {
+            renderTexture = UnityEngine.RenderTexture.GetTemporary(width, height);
+            Graphics.Blit(sourceTexture, renderTexture, material);
+            UnityEngine.RenderTexture.active = renderTexture;
+
+            bakedTexture = new UnityEngine.Texture2D(width, height);
+            bakedTexture.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+            bakedTexture.Apply();
+
+            return bakedTexture;
+        }
+        catch
+        {
+            if (bakedTexture != null)
+            {
+                UnityEngine.Object.DestroyImmediate(bakedTexture);
+            }
+
+            throw;
+        }
+        finally
+        {
+            UnityEngine.RenderTexture.active = currentRenderTexture;
+            if (renderTexture != null)
+            {
+                UnityEngine.RenderTexture.ReleaseTemporary(renderTexture);
+            }
         }
     }
 

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -28,10 +28,28 @@ public class LilToonXiexeConverter
         Xiexe.ShadowRim = Color.white.ToColorX_sRGB();
         Xiexe.ColorMask = (ColorMask)Material.GetFloat("_ColorMask");
         Xiexe.RenderQueue = Material.renderQueue;
+        UpdateOcclusion();
         UpdateOutline();
         UpdateShadowRamp();
 
         return Xiexe;
+    }
+
+    private void UpdateOcclusion()
+    {
+        if (Material.GetFloat("_UseShadow") == 0)
+        {
+            Xiexe.OcclusionColor = Color.black.ToColorX_sRGB();
+            return;
+        }
+
+        Xiexe.OcclusionMap = Context.GetITexture2D(Material.GetTexture("_ShadowBorderMask"));
+        Xiexe.OcclusionMapScale = Material.GetTextureScale("_ShadowBorderMask");
+        Xiexe.OcclusionMapOffset = Material.GetTextureOffset("_ShadowBorderMask");
+
+        var shadowColor = Material.GetColor("_ShadowColor");
+        var occlusionColor = Color.Lerp(Color.white, shadowColor, Material.GetFloat("_ShadowStrength"));
+        Xiexe.OcclusionColor = occlusionColor.ToColorX_Auto();
     }
 
     private void UpdateOutline()

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -28,11 +28,29 @@ public class LilToonXiexeConverter
         Xiexe.ShadowRim = Color.white.ToColorX_sRGB();
         Xiexe.ColorMask = (ColorMask)Material.GetFloat("_ColorMask");
         Xiexe.RenderQueue = Material.renderQueue;
+        UpdateOutline();
         UpdateShadowRamp();
 
         return Xiexe;
     }
 
+    private void UpdateOutline()
+    {
+        if (Material.GetFloat("_UseOutline") == 0 && !Material.shader.name.Contains("Outline", StringComparison.OrdinalIgnoreCase))
+        {
+            Xiexe.Outline = XiexeToonMaterial.OutlineStyle.None;
+            return;
+        }
+
+        Xiexe.Outline = Material.GetFloat("_OutlineEnableLighting") > 0
+            ? XiexeToonMaterial.OutlineStyle.Lit
+            : XiexeToonMaterial.OutlineStyle.Emissive;
+        Xiexe.OutlineWidth = Material.GetFloat("_OutlineWidth");
+        Xiexe.OutlineColor = Material.GetColor("_OutlineColor").ToColorX_Auto();
+        Xiexe.OutlineAlbedoTint = Material.GetFloat("_OutlineLitApplyTex") > 0;
+        Xiexe.OutlineMask = Context.GetITexture2D(Material.GetTexture("_OutlineWidthMask"));
+    }
+ 
     private void UpdateShadowRamp()
     {
         if (Material.GetFloat("_UseShadow") == 0)

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -296,6 +296,10 @@ public class LilToonXiexeConverter
         }
 
         var emissionColor = Material.GetColor("_EmissionColor");
+        var emissionAlpha = emissionColor.a;
+        // lilToon uses color alpha as blend strength; Xiexe emission ignores alpha.
+        emissionColor *= Mathf.Clamp01(Material.GetFloat("_EmissionBlend")) * emissionAlpha;
+        emissionColor.a = emissionAlpha;
         var emissionFluorescence = Mathf.Clamp01(Material.GetFloat("_EmissionFluorescence"));
         if (emissionFluorescence > 0)
         {
@@ -327,7 +331,7 @@ public class LilToonXiexeConverter
         // If the emission map is not UV0, baking will cause issues, so do not bake.
         if (hasEmissionMap && emissionMapUV != 0)
         {
-            Xiexe.EmissionMap = Context.GetITexture2D(emissionMap);
+            Xiexe.EmissionMap = Context.GetITexture2D(emissionMap, OpacifyProcessor);
             Xiexe.EmissionMapScale = Material.GetTextureScale("_EmissionMap");
             Xiexe.EmissionMapOffset = Material.GetTextureOffset("_EmissionMap");
             Xiexe.EmissionUV = emissionMapUV;
@@ -340,7 +344,7 @@ public class LilToonXiexeConverter
             UnityEngine.Debug.LogWarning("Could not find lilToon texture baker shader Hidden/ltsother_baker.");
             if (hasEmissionMap)
             {
-                Xiexe.EmissionMap = Context.GetITexture2D(emissionMap);
+                Xiexe.EmissionMap = Context.GetITexture2D(emissionMap, OpacifyProcessor);
                 Xiexe.EmissionMapScale = Material.GetTextureScale("_EmissionMap");
                 Xiexe.EmissionMapOffset = Material.GetTextureOffset("_EmissionMap");
                 Xiexe.EmissionUV = emissionMapUV;
@@ -397,9 +401,9 @@ public class LilToonXiexeConverter
                 ?? UnityEngine.Texture2D.whiteTexture;
             bakedTexture = BakeMaterialToTexture(sourceTexture2D, bakerMaterial);
             bakedTexture.name = $"{Material.name}_EmissionMap_Baked";
-            bakedTexture.wrapMode = emissionMap.wrapMode;
-            bakedTexture.filterMode = emissionMap.filterMode;
-            bakedTexture.anisoLevel = emissionMap.anisoLevel;
+            bakedTexture.wrapMode = sourceTexture2D.wrapMode;
+            bakedTexture.filterMode = sourceTexture2D.filterMode;
+            bakedTexture.anisoLevel = sourceTexture2D.anisoLevel;
         }
         catch (Exception exception)
         {
@@ -425,7 +429,7 @@ public class LilToonXiexeConverter
         }
 
         AssetCache.EmissionMap = bakedTexture;
-        Xiexe.EmissionMap = Context.GetITexture2D(bakedTexture);
+        Xiexe.EmissionMap = Context.GetITexture2D(bakedTexture, OpacifyProcessor);
         Xiexe.EmissionMapScale = Vector2.one;
         Xiexe.EmissionMapOffset = Vector2.zero;
         Xiexe.EmissionUV = 0;

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -1,0 +1,33 @@
+using FrooxEngine;
+using UnityEngine;
+
+public class LilToonXiexeConverter
+{
+    private readonly XiexeToonMaterial Xiexe;
+    private readonly UnityEngine.Material Material;
+    private readonly IConversionContext Context;
+    private readonly LilToonAssetCache AssetCache;
+
+    public LilToonXiexeConverter(XiexeToonMaterial Xiexe, UnityEngine.Material Material, IConversionContext Context, LilToonAssetCache AssetCache)
+    {
+        this.Xiexe = Xiexe;
+        this.Material = Material;
+        this.Context = Context;
+        this.AssetCache = AssetCache;
+    }
+
+    public IAssetProvider<FrooxEngine.Material> UpdateConversion()
+    {
+        Xiexe.MainTexture = Context.GetITexture2D(Material.mainTexture);
+        Xiexe.MainTextureScale = Material.mainTextureScale;
+        Xiexe.MainTextureOffset = Material.mainTextureOffset;
+        Xiexe.Color = Material.GetColor("_Color").ToColorX_sRGB();
+        Xiexe.Saturation = 1;
+        Xiexe.ShadowRim = Color.white.ToColorX_sRGB();
+        Xiexe.ColorMask = (ColorMask)Material.GetFloat("_ColorMask");
+        Xiexe.RenderQueue = Material.renderQueue;
+
+        return Xiexe;
+    }
+
+}

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -38,10 +38,8 @@ public class LilToonXiexeConverter
     {
         var mainTexture = GetMainTexture();
         UpdateMainTexture(mainTexture);
-        Xiexe.Saturation = 1;
+        UpdateRenderSettings();
         Xiexe.ShadowRim = Color.white.ToColorX_sRGB();
-        Xiexe.ColorMask = (ColorMask)Material.GetFloat("_ColorMask");
-        Xiexe.RenderQueue = Material.renderQueue;
         UpdateEmission(mainTexture.Texture, mainTexture.Scale, mainTexture.Offset);
         UpdateOcclusion();
         UpdateOutline();
@@ -174,8 +172,94 @@ public class LilToonXiexeConverter
         Xiexe.MainTextureScale = mainTextureData.Scale;
         Xiexe.MainTextureOffset = mainTextureData.Offset;
         Xiexe.Color = mainTextureData.Color.ToColorX_sRGB();
+        Xiexe.Saturation = 1;
     }
 
+    private void UpdateRenderSettings()
+    {
+        Xiexe.BlendMode = GetBlendMode();
+        Xiexe.AlphaClip = Material.GetFloat("_Cutoff");
+        Xiexe.ZWrite = Material.GetFloat("_ZWrite") > 0 ? ZWrite.On : ZWrite.Off;
+        Xiexe.Culling = (Culling)(UnityEngine.Rendering.CullMode)Material.GetFloat("_Cull");
+        Xiexe.ColorMask = (ColorMask)Material.GetFloat("_ColorMask");
+        Xiexe.RenderQueue = Material.renderQueue;
+    }
+
+    private BlendMode GetBlendMode()
+    {
+        var shaderName = Material.shader.name;
+
+        if (ContainsAfterLastSeparator(shaderName, "Multi") && Material.HasProperty("_TransparentMode"))
+        {
+            switch ((int)Material.GetFloat("_TransparentMode"))
+            {
+                case 0: // Opaque
+                    return BlendMode.Opaque;
+                case 1: // Cutout
+                case 5: // FurCutout
+                    return BlendMode.Cutout;
+                case 2: // Transparent
+                case 3: // Refraction
+                case 4: // Fur
+                    return BlendMode.Alpha;
+                case 6: // Gem
+                    return BlendMode.Additive;
+            }
+        }
+
+        if (ContainsAfterLastSeparator(shaderName, "Refraction"))
+        {
+            return BlendMode.Alpha;
+        }
+
+        if (ContainsAfterLastSeparator(shaderName, "Cutout"))
+        {
+            return BlendMode.Cutout;
+        }
+
+        if (ContainsAfterLastSeparator(shaderName, "Transparent") ||
+            ContainsAfterLastSeparator(shaderName, "Overlay") ||
+            IsLilToonFurShaderName(shaderName))
+        {
+            return BlendMode.Alpha;
+        }
+
+        if (ContainsAfterLastSeparator(shaderName, "Gem"))
+        {
+            return BlendMode.Additive;
+        }
+
+        return BlendMode.Opaque;
+    }
+
+    private static bool IsLilToonFurShaderName(string shaderName)
+    {
+        if (ContainsAfterLastSeparator(shaderName, "Fur"))
+        {
+            return true;
+        }
+
+        var separatorIndex = shaderName.LastIndexOf('/');
+        if (separatorIndex == -1 || separatorIndex + 1 == shaderName.Length)
+        {
+            return false;
+        }
+
+        var partIndex = shaderName.LastIndexOf("/[Optional] FurOnly/");
+        return partIndex != -1 && partIndex + 19 == separatorIndex;
+    }
+
+    private static bool ContainsAfterLastSeparator(string shaderName, string subName)
+    {
+        var separatorIndex = shaderName.LastIndexOf('/');
+        if (separatorIndex == -1 || separatorIndex + 1 == shaderName.Length)
+        {
+            return false;
+        }
+
+        return shaderName.IndexOf(subName, separatorIndex + 1) != -1;
+    }
+ 
     private void UpdateEmission(Texture mainTexture, Vector2 mainTextureScale, Vector2 mainTextureOffset)
     {
         if (Material.GetFloat("_UseEmission") == 0)

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs
@@ -744,6 +744,7 @@ public class LilToonXiexeConverter
             hash.Add(Material.GetTexture("_EmissionMap"));
             hash.Add(Material.GetTextureScale("_EmissionMap"));
             hash.Add(Material.GetTextureOffset("_EmissionMap"));
+            hash.Add(Material.GetFloat("_EmissionMap_UVMode"));
         }
         if (emissionBlendMask != null)
         {

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs.meta
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/lilToon/LilToonXiexeConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 726160a8783fc4340bbd8aee1b1371d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
related issue: #38

This PR implements conversion support for lilToon shader materials.

Although not every lilToon feature is supported, the converter should preserve the overall appearance of materials reasonably well.

To reproduce lilToon's appearance using XiexeToon, the converter generates several textures:

- `MainTexture` to support `MainTexture2nd`, `MainTexture3rd`, and `AlphaMask`
- `EmissionMap`
- `ShadowRamp`

Some features are intentionally excluded because they cannot be reproduced accurately and would significantly affect the resulting appearance:

- `FakeShadow` shader
- `MainTexture2nd` and `MainTexture3rd` using UV modes other than UV0
- MatCaps using blend modes other than Additive, or using a MatCap mask
- `NormalMap2nd`  
  This should be possible by combining the normal maps, but it is not implemented in this PR because I was unsure of the correct way to combine them.

Unity:
<img width="1118" height="534" alt="image" src="https://github.com/user-attachments/assets/245d7a7d-a302-46f8-983b-c086da0f174f" />

Resonite:
<img width="1920" height="1080" alt="2026-06-06 16 28 20" src="https://github.com/user-attachments/assets/60f9b292-3dfa-43f3-8f2b-cf3df72b7425" />

