### PR TITLE
[MToon] Improve outline and rim conversion

### DIFF
--- a/Assets/ResoniteSDK/MaterialConverters/Custom/MToon/MToon10XiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/MToon/MToon10XiexeConverter.cs
@@ -1,4 +1,5 @@
 using FrooxEngine;
+using ResoniteLink;
 using UnityEngine;
 
 public static class MToon10XiexeConverter
@@ -9,6 +10,9 @@ public static class MToon10XiexeConverter
     private const int OutlineWidthModeNone = 0;
     private const int OutlineWidthModeWorld = 1;
     private const int OutlineWidthModeScreen = 2;
+
+    private static readonly AssetMessagePostProcessor OutlineMaskProcessor =
+        TexturePostProcessing.ProcessPixels(ConvertOutlineMask);
 
     public static IAssetProvider<FrooxEngine.Material> UpdateConversion(
         FrooxEngine.XiexeToonMaterial xiexe,
@@ -110,7 +114,8 @@ public static class MToon10XiexeConverter
 
     private static void UpdateOutline(FrooxEngine.XiexeToonMaterial xiexe, UnityEngine.Material material, IConversionContext context)
     {
-        if (GetOutlineWidthMode(material) == OutlineWidthModeNone ||
+        var outlineWidthMode = GetOutlineWidthMode(material);
+        if (outlineWidthMode == OutlineWidthModeNone ||
             material.GetFloat("_OutlineWidth") <= 0)
         {
             xiexe.Outline = XiexeToonMaterial.OutlineStyle.None;
@@ -130,10 +135,29 @@ public static class MToon10XiexeConverter
             xiexe.Outline = XiexeToonMaterial.OutlineStyle.Emissive;
         }
 
-        xiexe.OutlineWidth = material.GetFloat("_OutlineWidth");
+        // Xiexe extrudes by OutlineWidth * 0.01. Multiplying MToon 1.0's
+        // outline factor by 100 preserves world width exactly at model scale 1
+        // and gives screen-coordinate outlines a practical object-space
+        // approximation at typical avatar viewing distances.
+        xiexe.OutlineWidth = Mathf.Clamp(material.GetFloat("_OutlineWidth") * 100, 0, 5);
+
         xiexe.OutlineColor = material.GetColor("_OutlineColor").ToColorX_sRGB();
         xiexe.OutlineAlbedoTint = material.GetFloat("_OutlineLightingMix") >= 0.5f;
-        xiexe.OutlineMask = context.GetITexture2D(material.GetTexture("_OutlineWidthTex"));
+        xiexe.OutlineMask = context.GetITexture2D(material.GetTexture("_OutlineWidthTex"), OutlineMaskProcessor);
+    }
+
+    private static color ConvertOutlineMask(color c)
+    {
+        // MToon 1.0 packs shading shift, outline width, and UV animation mask into
+        // the R, G, and B channels of a shared parameter map. Xiexe samples its
+        // standalone outline mask from R, so copy MToon's G value into RGB.
+        return new color
+        {
+            r = c.g,
+            g = c.g,
+            b = c.g,
+            a = c.a,
+        };
     }
 
     private static int GetOutlineWidthMode(UnityEngine.Material material)

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/MToon/MToon10XiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/MToon/MToon10XiexeConverter.cs
@@ -103,13 +103,17 @@ public static class MToon10XiexeConverter
     private static void UpdateRim(FrooxEngine.XiexeToonMaterial xiexe, UnityEngine.Material material)
     {
         var rimColor = material.GetColor("_RimColor");
+        var fresnelPower = Mathf.Max(material.GetFloat("_RimFresnelPower"), 0.001f);
+        var halfIntensityPoint = Mathf.Pow(0.5f, 1 / fresnelPower);
+        var halfIntensitySlope = fresnelPower * Mathf.Pow(0.5f, (fresnelPower - 1) / fresnelPower);
+
         xiexe.RimColor = rimColor.ToColorX_sRGB();
         xiexe.RimAlbedoTint = 0;
         xiexe.RimAttenuationEffect = material.GetFloat("_RimLightingMix");
         xiexe.RimIntensity = rimColor.maxColorComponent;
-        xiexe.RimRange = 1 / Mathf.Max(material.GetFloat("_RimFresnelPower"), 0.001f);
-        xiexe.RimThreshold = material.GetFloat("_RimLift");
-        xiexe.RimSharpness = 0.5f;
+        xiexe.RimRange = Mathf.Clamp01(halfIntensityPoint - material.GetFloat("_RimLift"));
+        xiexe.RimThreshold = 0;
+        xiexe.RimSharpness = Mathf.Clamp(0.75f / halfIntensitySlope, 0.01f, 1);
     }
 
     private static void UpdateOutline(FrooxEngine.XiexeToonMaterial xiexe, UnityEngine.Material material, IConversionContext context)

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/MToon/MToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/MToon/MToonXiexeConverter.cs
@@ -111,7 +111,8 @@ public static class MToonXiexeConverter
 
     private static void UpdateOutline(FrooxEngine.XiexeToonMaterial xiexe, UnityEngine.Material material, IConversionContext context)
     {
-        if (GetOutlineWidthMode(material) == OutlineWidthModeNone ||
+        var outlineWidthMode = GetOutlineWidthMode(material);
+        if (outlineWidthMode == OutlineWidthModeNone ||
             material.GetFloat("_OutlineWidth") <= 0)
         {
             xiexe.Outline = XiexeToonMaterial.OutlineStyle.None;
@@ -122,18 +123,31 @@ public static class MToonXiexeConverter
             return;
         }
 
-        if (material.GetFloat("_OutlineColorMode") > 0 || material.GetFloat("_OutlineLightingMix") >= 0.5f)
+        if (material.GetFloat("_OutlineColorMode") > 0 && material.GetFloat("_OutlineLightingMix") >= 0.5f)
         {
             xiexe.Outline = XiexeToonMaterial.OutlineStyle.Lit;
+            xiexe.OutlineAlbedoTint = true;
         }
         else
         {
             xiexe.Outline = XiexeToonMaterial.OutlineStyle.Emissive;
+            xiexe.OutlineAlbedoTint = false;
         }
 
-        xiexe.OutlineWidth = material.GetFloat("_OutlineWidth");
-        xiexe.OutlineColor = material.GetColor("_OutlineColor").ToColorX_Linear();
-        xiexe.OutlineAlbedoTint = material.GetFloat("_OutlineLightingMix") >= 0.5f;
+        var outlineWidth = material.GetFloat("_OutlineWidth");
+        if (outlineWidthMode == OutlineWidthModeScreen)
+        {
+            // UniVRM migrates legacy screen width to the VRM 1.0 screen-height
+            // ratio with width * 0.01 * 0.5. Xiexe has no screen-space outline,
+            // so retain the corresponding half-width damping as an approximation.
+            xiexe.OutlineWidth = Mathf.Clamp(outlineWidth * 0.5f, 0, 5);
+        }
+        else
+        {
+            xiexe.OutlineWidth = Mathf.Clamp(outlineWidth, 0, 5);
+        }
+
+        xiexe.OutlineColor = material.GetColor("_OutlineColor").ToColorX_sRGB();
         xiexe.OutlineMask = context.GetITexture2D(material.GetTexture("_OutlineWidthTexture"));
     }
 

--- a/Assets/ResoniteSDK/MaterialConverters/Custom/MToon/MToonXiexeConverter.cs
+++ b/Assets/ResoniteSDK/MaterialConverters/Custom/MToon/MToonXiexeConverter.cs
@@ -100,13 +100,17 @@ public static class MToonXiexeConverter
     private static void UpdateRim(FrooxEngine.XiexeToonMaterial xiexe, UnityEngine.Material material)
     {
         var rimColor = material.GetColor("_RimColor");
+        var fresnelPower = Mathf.Max(material.GetFloat("_RimFresnelPower"), 0.001f);
+        var halfIntensityPoint = Mathf.Pow(0.5f, 1 / fresnelPower);
+        var halfIntensitySlope = fresnelPower * Mathf.Pow(0.5f, (fresnelPower - 1) / fresnelPower);
+
         xiexe.RimColor = rimColor.ToColorX_sRGB();
         xiexe.RimAlbedoTint = 0;
         xiexe.RimAttenuationEffect = material.GetFloat("_RimLightingMix");
         xiexe.RimIntensity = rimColor.maxColorComponent;
-        xiexe.RimRange = 1 / Mathf.Max(material.GetFloat("_RimFresnelPower"), 0.001f);
-        xiexe.RimThreshold = material.GetFloat("_RimLift");
-        xiexe.RimSharpness = 0.5f;
+        xiexe.RimRange = Mathf.Clamp01(halfIntensityPoint - material.GetFloat("_RimLift"));
+        xiexe.RimThreshold = 0;
+        xiexe.RimSharpness = Mathf.Clamp(0.75f / halfIntensitySlope, 0.01f, 1);
     }
 
     private static void UpdateOutline(FrooxEngine.XiexeToonMaterial xiexe, UnityEngine.Material material, IConversionContext context)


### PR DESCRIPTION
## Summary

Improves Outline and Rim conversion from MToon 0.x and MToon 1.0 materials to XiexeToon.

## Changes

- MToon 0.x Outline
  - Adjusts screen-coordinate width based on UniVRM's MToon 1.0 migration behavior
  - Converts OutlineColor using the sRGB color profile
  - Selects the appropriate Outline style based on Fixed Color and Lighting Mix

- MToon 1.0 Outline
  - Converts OutlineWidth to match Xiexe's object-space width
  - Copies the shared parameter map's G channel into R for Xiexe's OutlineMask

- MToon 0.x and MToon 1.0 Rim
  - Approximates Xiexe's RimRange and RimSharpness from MToon's Fresnel Power and Rim Lift
  - Disables Xiexe's RimThreshold lighting dependency

## Limitations

XiexeToon does not provide a screen-coordinate Outline mode. MToon screen-coordinate Outlines are therefore converted to an object-space approximation.

## References

- https://github.com/Yellow-Dog-Man/Resonite.UnityShaders / XiexeToon
- https://github.com/vrm-c/vrm-specification
- https://github.com/vrm-c/UniVRM
- https://github.com/orange3134/VRMtoResonitePackage
